### PR TITLE
HIVEMALL-22: Remove migrating repository alert

### DIFF
--- a/src/site/xdoc/index.xml.vm
+++ b/src/site/xdoc/index.xml.vm
@@ -27,8 +27,8 @@
     </head>
     <body>
         <div class="alert alert-info" role="alert">
-            <strong>Info:</strong> We are now in the process of migrating the project repository from <a href="https://github.com/myui/hivemall">Github</a> to <a href="https://github.com/apache/incubator-hivemall">Apache Incubator</a>.
-            <a href="/userguide/index.html"><button class="btn btn-primary" type="button">Learn more</button></a>
+          <strong>Info:</strong> Out project repository was migrated to <a href="https://github.com/apache/incubator-hivemall">Apache Incubator</a>.
+          <a href="/userguide/index.html"><button class="btn btn-primary" type="button">Learn more</button></a>
         </div>
         <div id="carousel-main" class="row">
             <div id="screenshots-carousel" class="carousel slide span10">


### PR DESCRIPTION
Since migration of repository has been done, we can remove migrating alert.

https://issues.apache.org/jira/browse/HIVEMALL-22