### PR TITLE
Make sha1 deprecated

### DIFF
--- a/resources/ddl/define-all-as-permanent.deprecated.hive
+++ b/resources/ddl/define-all-as-permanent.deprecated.hive
@@ -75,3 +75,6 @@ CREATE FUNCTION rescale_fv as 'hivemall.ftvec.scaling.RescaleUDF' USING JAR '${h
 
 DROP FUNCTION IF EXISTS addBias;
 CREATE FUNCTION addBias as 'hivemall.ftvec.AddBiasUDF' USING JAR '${hivemall_jar}';
+
+DROP FUNCTION IF EXISTS sha1;
+CREATE FUNCTION sha1 as 'hivemall.ftvec.hashing.Sha1UDF' USING JAR '${hivemall_jar}';

--- a/resources/ddl/define-all-as-permanent.hive
+++ b/resources/ddl/define-all-as-permanent.hive
@@ -167,9 +167,6 @@ CREATE FUNCTION argmin_kld as 'hivemall.ensemble.ArgminKLDistanceUDAF' USING JAR
 DROP FUNCTION IF EXISTS mhash;
 CREATE FUNCTION mhash as 'hivemall.ftvec.hashing.MurmurHash3UDF' USING JAR '${hivemall_jar}';
 
-DROP FUNCTION IF EXISTS sha1;
-CREATE FUNCTION sha1 as 'hivemall.ftvec.hashing.Sha1UDF' USING JAR '${hivemall_jar}';
-
 DROP FUNCTION IF EXISTS array_hash_values;
 CREATE FUNCTION array_hash_values as 'hivemall.ftvec.hashing.ArrayHashValuesUDF' USING JAR '${hivemall_jar}';
 

--- a/resources/ddl/define-all.deprecated.hive
+++ b/resources/ddl/define-all.deprecated.hive
@@ -78,3 +78,6 @@ create temporary function rescale_fv as 'hivemall.ftvec.scaling.RescaleUDF';
 
 drop temporary function addBias;
 create temporary function addBias as 'hivemall.ftvec.AddBiasUDF';
+
+drop temporary function sha1;
+create temporary function sha1 as 'hivemall.ftvec.hashing.Sha1UDF';

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -163,9 +163,6 @@ create temporary function argmin_kld as 'hivemall.ensemble.ArgminKLDistanceUDAF'
 drop temporary function mhash;
 create temporary function mhash as 'hivemall.ftvec.hashing.MurmurHash3UDF';
 
-drop temporary function sha1;
-create temporary function sha1 as 'hivemall.ftvec.hashing.Sha1UDF';
-
 drop temporary function array_hash_values;
 create temporary function array_hash_values as 'hivemall.ftvec.hashing.ArrayHashValuesUDF';
 

--- a/resources/ddl/define-all.spark
+++ b/resources/ddl/define-all.spark
@@ -151,8 +151,8 @@ sqlContext.sql("CREATE TEMPORARY FUNCTION argmin_kld AS 'hivemall.ensemble.Argmi
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS mhash")
 sqlContext.sql("CREATE TEMPORARY FUNCTION mhash AS 'hivemall.ftvec.hashing.MurmurHash3UDF'")
 
-sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS sha1")
-sqlContext.sql("CREATE TEMPORARY FUNCTION sha1 AS 'hivemall.ftvec.hashing.Sha1UDF'")
+// sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS sha1")
+// sqlContext.sql("CREATE TEMPORARY FUNCTION sha1 AS 'hivemall.ftvec.hashing.Sha1UDF'")
 
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS array_hash_values")
 sqlContext.sql("CREATE TEMPORARY FUNCTION array_hash_values AS 'hivemall.ftvec.hashing.ArrayHashValuesUDF'")


### PR DESCRIPTION
`sha1` is natively supported from Hive version `1.3.0` or later.
So, this pull request makes Hivemall's `sha1` deprecated.