### PR TITLE
[HIVEMALL-28] Set HIVEMALL_HOME to absolute path

### DIFF
--- a/bin/build_xgboost.sh
+++ b/bin/build_xgboost.sh
@@ -27,9 +27,9 @@ XGBOOST_HASHVAL='7ab15a0b31c870c7779691639f521df3ccd4a56e'
 # Move to a top directory
 if [ "$HIVEMALL_HOME" == "" ]; then
   if [ -e ../bin/${0##*/} ]; then
-    HIVEMALL_HOME=".."
+    HIVEMALL_HOME=`pwd`/..
   elif [ -e ./bin/${0##*/} ]; then
-    HIVEMALL_HOME="."
+    HIVEMALL_HOME=`pwd`
   else
     echo "env HIVEMALL_HOME not defined"
     exit 1


### PR DESCRIPTION
## What does this pull request solve?

Set `HIVEMALL_HOME` to absolute path when execute `bin/build_xgboost.sh`.

## How was this patch tested?

Manual test.