### PR TITLE
[HIVEMALL-37][SPARK] Support  a SST-based change-point detector in DataFrame/Spark

### DIFF
--- a/spark/spark-2.0/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
+++ b/spark/spark-2.0/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
@@ -41,6 +41,7 @@ import org.apache.spark.unsafe.types.UTF8String
  * @groupname classifier
  * @groupname classifier.multiclass
  * @groupname xgboost
+ * @groupname anomaly
  * @groupname knn.similarity
  * @groupname knn.distance
  * @groupname knn.lsh
@@ -852,6 +853,19 @@ object HivemallOps {
       "hivemall.HivemallVersionUDF",
       "hivemall_version",
       Nil
+    )
+  }
+
+  /**
+   * @see [[hivemall.anomaly.SingularSpectrumTransformUDF]]
+   * @group anomaly
+   */
+  @scala.annotation.varargs
+  def sst(exprs: Column*): Column = withExpr {
+    planHiveGenericUDF(
+      "hivemall.anomaly.SingularSpectrumTransformUDF",
+      "sst",
+      exprs
     )
   }
 

--- a/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
+++ b/spark/spark-2.0/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
@@ -30,6 +30,13 @@ import org.apache.spark.test.TestFPWrapper._
 
 final class HivemallOpsWithFeatureSuite extends HivemallFeatureQueryTest {
 
+  test("anomaly") {
+    import hiveContext.implicits._
+    val df = spark.range(1000).selectExpr("id AS time", "rand() AS x")
+    // TODO: Test results more exactly
+    assert(df.sort($"time".asc).select(sst($"x", lit("-th 0.005"))).count === 1000)
+  }
+
   test("knn.similarity") {
     val df1 = DummyInputData.select(cosine_sim(lit2(Seq(1, 2, 3, 4)), lit2(Seq(3, 4, 5, 6))))
     assert(df1.collect.apply(0).getFloat(0) ~== 0.500f)


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr supported a SST-based change-point detector as `sst` in `HivemallOps`.

## What type of PR is it?
Feature

### What is the Jira issue?
https://issues.apache.org/jira/browse/HIVEMALL-37

## How was this patch tested?
Added a test in `HivemallOpsSuite`.
