### PR TITLE
[HIVEMALL-42][DOC] Fix the link to license file in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Apache Hivemall: Hive scalable machine learning library
 =======================================================
 [![Build Status](https://travis-ci.org/apache/incubator-hivemall.svg?branch=master)](https://travis-ci.org/apache/incubator-hivemall)
 [![Documentation Status](https://img.shields.io/:docs-latest-green.svg)](http://hivemall.incubator.apache.org/userguide/)
-[![License](http://img.shields.io/:license-Apache_v2-blue.svg)](https://github.com/myui/hivemall/blob/master/LICENSE)
+[![License](http://img.shields.io/:license-Apache_v2-blue.svg)](https://github.com/apache/incubator-hivemall/blob/master/LICENSE)
 [![Coverage Status](https://coveralls.io/repos/github/apache/incubator-hivemall/badge.svg?branch=master)](https://coveralls.io/github/apache/incubator-hivemall?branch=master)
 [![Twitter Follow](https://img.shields.io/twitter/follow/ApacheHivemall.svg?style=social&label=Follow)](https://twitter.com/ApacheHivemall)
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a dead link to the license file.

## What type of PR is it?

Documentation

### What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-42

## How was this patch tested?

Clicked the link at https://github.com/aajisaka/incubator-hivemall/blob/HIVEMALL-42/README.md
