### PR TITLE
Added rownum() UDF

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -6,10 +6,14 @@
 
 [Bug Fix | Improvement | Feature | Documentation | Hot Fix | Refactoring]
 
-### What is the Jira issue?
+## What is the Jira issue?
 
 (Put link here and add [HIVEMALL-*Jira number*] in PR title, e.g., [HIVEMALL-533])
 
 ## How was this patch tested?
 
 (Please explain how this patch was tested. e.g., unit tests, integration tests, manual tests)
+
+## How to use this feature?
+
+(Please remove this section if not needed)

--- a/core/src/main/java/hivemall/tools/mapred/RowNumberUDF.java
+++ b/core/src/main/java/hivemall/tools/mapred/RowNumberUDF.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.tools.mapred;
+
+import hivemall.utils.hadoop.HadoopUtils;
+
+import javax.annotation.Nonnull;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.UDFType;
+import org.apache.hadoop.io.LongWritable;
+
+@Description(name = "rownum", value = "_FUNC_() - Returns a generated row number in long",
+        extended = "returns sprintf(`%d%04d`,sequence,taskId) as long")
+@UDFType(deterministic = false, stateful = true)
+public final class RowNumberUDF extends UDF {
+
+    private long sequence;
+    private int taskId;
+    @Nonnull
+    private final LongWritable result;
+
+    public RowNumberUDF() {
+        this.sequence = 0L;
+        this.taskId = -1;
+        this.result = new LongWritable(Double.doubleToLongBits(Double.NaN));
+    }
+
+    @Nonnull
+    public LongWritable evaluate() throws HiveException {
+        if (taskId == -1) {
+            this.taskId = HadoopUtils.getTaskId() + 1;
+            if (taskId > 9999) {
+                throw new HiveException("TaskId out of range `" + taskId
+                        + "`. rownum() supports 9999 tasks at max");
+            }
+        }
+        sequence++;
+
+        String rowid = String.format("%d%04d", sequence, taskId);
+        final long l;
+        try {
+            l = Long.parseLong(rowid);
+        } catch (NumberFormatException e) {
+            throw new HiveException("failed to parse `" + rowid + "` as long", e);
+        }
+
+        result.set(l);
+        return result;
+    }
+}

--- a/resources/ddl/define-all-as-permanent.hive
+++ b/resources/ddl/define-all-as-permanent.hive
@@ -477,6 +477,9 @@ CREATE FUNCTION jobid as 'hivemall.tools.mapred.JobIdUDF' USING JAR '${hivemall_
 DROP FUNCTION IF EXISTS rowid;
 CREATE FUNCTION rowid as 'hivemall.tools.mapred.RowIdUDF' USING JAR '${hivemall_jar}';
 
+DROP FUNCTION IF EXISTS rownum;
+CREATE FUNCTION rownum as 'hivemall.tools.mapred.RowNumberUDF' USING JAR '${hivemall_jar}';
+
 DROP FUNCTION IF EXISTS distcache_gets;
 CREATE FUNCTION distcache_gets as 'hivemall.tools.mapred.DistributedCacheLookupUDF' USING JAR '${hivemall_jar}';
 

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -473,6 +473,9 @@ create temporary function jobid as 'hivemall.tools.mapred.JobIdUDF';
 drop temporary function if exists rowid;
 create temporary function rowid as 'hivemall.tools.mapred.RowIdUDF';
 
+drop temporary function if exists rownum;
+create temporary function rownum as 'hivemall.tools.mapred.RowNumberUDF';
+
 drop temporary function if exists distcache_gets;
 create temporary function distcache_gets as 'hivemall.tools.mapred.DistributedCacheLookupUDF';
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add rownum() UDF that returns sprintf(`%d%04d`,sequence,taskId) as long where tasks are limited to at max 9999.

## What type of PR is it?

Feature

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-64

## How was this patch tested?

manual tests

## How to use this feature?

```sql
create table yyy 
as
select 
  rownum() as rowid, 
  *
from 
  xxx;
```

Caution: `rownum()` would not properly work for local task execution.