### PR TITLE
[HIVEMALL-72] Fix corner-case rescale UDF behavior to return range [0.0,1.0]

### DIFF
--- a/core/src/main/java/hivemall/ftvec/scaling/RescaleUDF.java
+++ b/core/src/main/java/hivemall/ftvec/scaling/RescaleUDF.java
@@ -107,10 +107,10 @@ public final class RescaleUDF extends UDF {
             return 0.5f;
         }
         if (value < min) {
-            return min;
+            return 0.f;
         }
         if (value > max) {
-            return max;
+            return 1.f;
         }
         return (value - min) / (max - min);
     }

--- a/core/src/main/java/hivemall/ftvec/scaling/RescaleUDF.java
+++ b/core/src/main/java/hivemall/ftvec/scaling/RescaleUDF.java
@@ -106,6 +106,12 @@ public final class RescaleUDF extends UDF {
         if (min == max) {
             return 0.5f;
         }
+        if (value < min) {
+            return min;
+        }
+        if (value > max) {
+            return max;
+        }
         return (value - min) / (max - min);
     }
 

--- a/core/src/test/java/hivemall/ftvec/scaling/RescaleUDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/scaling/RescaleUDFTest.java
@@ -96,6 +96,8 @@ public class RescaleUDFTest {
     public void testMinMaxCornercase() throws Exception {
         assertEquals(WritableUtils.val(1.0f), udf.evaluate(1.1f, 0.0f, 1.0f));
         assertEquals(WritableUtils.val(0.0f), udf.evaluate(-0.1f, 0.0f, 1.0f));
+        assertEquals(WritableUtils.val(1.0f), udf.evaluate(4.1f, 0.0f, 3.0f));
+        assertEquals(WritableUtils.val(0.0f), udf.evaluate(-2.1f, -1.0f, 1.0f));
     }
 
     @Test(expected = HiveException.class)

--- a/core/src/test/java/hivemall/ftvec/scaling/RescaleUDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/scaling/RescaleUDFTest.java
@@ -87,8 +87,15 @@ public class RescaleUDFTest {
         udf.evaluate("1:string", 0.1d, 0.1d);
     }
 
+    @Test
     public void testMinMaxEquals() throws Exception {
-        udf.evaluate(0.1d, 0.1d, 0.1d);
+        assertEquals(WritableUtils.val(0.5f), udf.evaluate(0.1d, 0.1d, 0.1d));
+    }
+
+    @Test
+    public void testMinMaxCornercase() throws Exception {
+        assertEquals(WritableUtils.val(1.0f), udf.evaluate(1.1f, 0.0f, 1.0f));
+        assertEquals(WritableUtils.val(0.0f), udf.evaluate(-0.1f, 0.0f, 1.0f));
     }
 
     @Test(expected = HiveException.class)


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix rescale UDF behavior to return range `[0.0,1.0]`.

## What type of PR is it?

Bug Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-72

## How was this patch tested?

manual tests

```sql
-- Before
select rescale(4.2,1.0,3.0),rescale(-0.3, 1.0, 3.0);
> 1.5999999	-0.65

-- After
select rescale(4.2,1.0,3.0),rescale(-0.3, 1.0, 3.0);
> 1.0 0.0
```
