### PR TITLE
[HIVEMALL-85] Upgrade hivemall-xgboost's hadoop version to 2.6.5

### DIFF
--- a/xgboost/pom.xml
+++ b/xgboost/pom.xml
@@ -41,8 +41,8 @@
 		<!-- provided scope -->
 		<dependency>
 			<groupId>org.apache.hadoop</groupId>
-			<artifactId>hadoop-core</artifactId>
-			<version>0.20.2-cdh3u6</version>
+			<artifactId>hadoop-client</artifactId>
+			<version>2.6.5</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Upgrade hivemall-xgboost's hadoop version to 2.6.5

## What type of PR is it?

Improvement

## What is the Jira issue?

[HIVEMALL-85](https://issues.apache.org/jira/browse/HIVEMALL-85)

## How was this patch tested?

manual tests

