### PR TITLE
[HIVEMALL-88][SPARK] Support a function to flatten nested schemas

### DIFF
--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -163,6 +163,7 @@
 
 * [Generic features](spark/misc/misc.md)
     * [Top-k Join processing](spark/misc/topk_join.md)
+    * [Ohter utility functions](spark/misc/functions.md)
 
 ## Part X - External References
 

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -163,7 +163,7 @@
 
 * [Generic features](spark/misc/misc.md)
     * [Top-k Join processing](spark/misc/topk_join.md)
-    * [Ohter utility functions](spark/misc/functions.md)
+    * [Other utility functions](spark/misc/functions.md)
 
 ## Part X - External References
 

--- a/docs/gitbook/spark/misc/functions.md
+++ b/docs/gitbook/spark/misc/functions.md
@@ -1,0 +1,47 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+`df.flatten()` flattens a nested schema of `df` into a flat one.
+
+# Usage
+
+```scala
+scala> val df = Seq((0, (1, (3.0, "a")), (5, 0.9))).toDF()
+scala> df.printSchema
+root
+ |-- _1: integer (nullable = false)
+ |-- _2: struct (nullable = true)
+ |    |-- _1: integer (nullable = false)
+ |    |-- _2: struct (nullable = true)
+ |    |    |-- _1: double (nullable = false)
+ |    |    |-- _2: string (nullable = true)
+ |-- _3: struct (nullable = true)
+ |    |-- _1: integer (nullable = false)
+ |    |-- _2: double (nullable = false)
+
+scala> df.flatten.printSchema
+root
+ |-- _1: integer (nullable = false)
+ |-- _2._1: integer (nullable = true)
+ |-- _2._2._1: double (nullable = true)
+ |-- _2._2._2: string (nullable = true)
+ |-- _3._1: integer (nullable = true)
+ |-- _3._2: double (nullable = true)
+```
+

--- a/docs/gitbook/spark/misc/functions.md
+++ b/docs/gitbook/spark/misc/functions.md
@@ -35,13 +35,13 @@ root
  |    |-- _1: integer (nullable = false)
  |    |-- _2: double (nullable = false)
 
-scala> df.flatten.printSchema
+scala> df.flatten(separator = "$").printSchema
 root
  |-- _1: integer (nullable = false)
- |-- _2._1: integer (nullable = true)
- |-- _2._2._1: double (nullable = true)
- |-- _2._2._2: string (nullable = true)
- |-- _3._1: integer (nullable = true)
- |-- _3._2: double (nullable = true)
+ |-- _2$_1: integer (nullable = true)
+ |-- _2$_2$_1: double (nullable = true)
+ |-- _2$_2$_2: string (nullable = true)
+ |-- _3$_1: integer (nullable = true)
+ |-- _3$_2: double (nullable = true)
 ```
 

--- a/spark/spark-2.1/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
+++ b/spark/spark-2.1/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
@@ -466,17 +466,25 @@ final class HivemallOpsWithFeatureSuite extends HivemallFeatureQueryTest {
     val df = Seq((0, (1, "a", (3.0, "b")), (5, 0.9, "c", "d"), 9)).toDF()
     assert(df.flatten().schema === StructType(
       StructField("_1", IntegerType, nullable = false) ::
-      StructField("_2._1", IntegerType, nullable = true) ::
-      StructField("_2._2", StringType, nullable = true) ::
-      StructField("_2._3._1", DoubleType, nullable = true) ::
-      StructField("_2._3._2", StringType, nullable = true) ::
-      StructField("_3._1", IntegerType, nullable = true) ::
-      StructField("_3._2", DoubleType, nullable = true) ::
-      StructField("_3._3", StringType, nullable = true) ::
-      StructField("_3._4", StringType, nullable = true) ::
+      StructField("_2$_1", IntegerType, nullable = true) ::
+      StructField("_2$_2", StringType, nullable = true) ::
+      StructField("_2$_3$_1", DoubleType, nullable = true) ::
+      StructField("_2$_3$_2", StringType, nullable = true) ::
+      StructField("_3$_1", IntegerType, nullable = true) ::
+      StructField("_3$_2", DoubleType, nullable = true) ::
+      StructField("_3$_3", StringType, nullable = true) ::
+      StructField("_3$_4", StringType, nullable = true) ::
       StructField("_4", IntegerType, nullable = false) ::
       Nil
     ))
+    checkAnswer(df.flatten("$").select("_2$_1"), Row(1))
+    checkAnswer(df.flatten("_").select("_2__1"), Row(1))
+    checkAnswer(df.flatten(".").select("`_2._1`"), Row(1))
+
+    val errMsg1 = intercept[IllegalArgumentException] { df.flatten("\t") }
+    assert(errMsg1.getMessage.startsWith("Must use '$', '_', or '.' for separator, but got"))
+    val errMsg2 = intercept[IllegalArgumentException] { df.flatten("12") }
+    assert(errMsg2.getMessage.startsWith("Separator cannot be more than one character:"))
   }
 
   /**

--- a/spark/spark-2.1/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
+++ b/spark/spark-2.1/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
@@ -461,6 +461,24 @@ final class HivemallOpsWithFeatureSuite extends HivemallFeatureQueryTest {
     }
   }
 
+  test("misc - flatten") {
+    import hiveContext.implicits._
+    val df = Seq((0, (1, "a", (3.0, "b")), (5, 0.9, "c", "d"), 9)).toDF()
+    assert(df.flatten().schema === StructType(
+      StructField("_1", IntegerType, nullable = false) ::
+      StructField("_2._1", IntegerType, nullable = true) ::
+      StructField("_2._2", StringType, nullable = true) ::
+      StructField("_2._3._1", DoubleType, nullable = true) ::
+      StructField("_2._3._2", StringType, nullable = true) ::
+      StructField("_3._1", IntegerType, nullable = true) ::
+      StructField("_3._2", DoubleType, nullable = true) ::
+      StructField("_3._3", StringType, nullable = true) ::
+      StructField("_3._4", StringType, nullable = true) ::
+      StructField("_4", IntegerType, nullable = false) ::
+      Nil
+    ))
+  }
+
   /**
    * This test fails because;
    *


### PR DESCRIPTION
## What changes were proposed in this pull request?
Since parquet is first-citizen in Spark, most of users use nested schemas in DF. In some usecases, they need to flatten nested schemas into flat ones to dump data into the other systems that do not support nested schemas, e.g., RDBMS. So, this pr added a conversion function from nested schemas to flat ones.

## What type of PR is it?
Improvement

## What is the Jira issue?
https://issues.apache.org/jira/browse/HIVEMALL-88

## How was this patch tested?
Added tests in `HivemallOpsSuite`.