### PR TITLE
[HIVEMALL-101] Separate optimizer implementation

### DIFF
--- a/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
@@ -1,0 +1,369 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall;
+
+import hivemall.annotations.VisibleForTesting;
+import hivemall.model.*;
+import hivemall.model.WeightValue.WeightValueWithCovar;
+import hivemall.optimizer.LossFunctions;
+import hivemall.optimizer.LossFunctions.LossFunction;
+import hivemall.optimizer.LossFunctions.LossType;
+import hivemall.optimizer.Optimizer;
+import hivemall.optimizer.OptimizerOptions;
+import hivemall.utils.collections.IMapIterator;
+import hivemall.utils.hadoop.HiveUtils;
+import hivemall.utils.lang.FloatAccumulator;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.*;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+import org.apache.hadoop.io.FloatWritable;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
+    private static final Log logger = LogFactory.getLog(GeneralLearnerBaseUDTF.class);
+
+    private ListObjectInspector featureListOI;
+    private PrimitiveObjectInspector featureInputOI;
+    private PrimitiveObjectInspector targetOI;
+    private boolean parseFeature;
+
+    @Nonnull
+    private final Map<String, String> optimizerOptions;
+    private Optimizer optimizer;
+    private LossFunction lossFunction;
+
+    protected PredictionModel model;
+    protected int count;
+
+    // The accumulated delta of each weight values.
+    protected transient Map<Object, FloatAccumulator> accumulated;
+    protected int sampled;
+
+    private float cumLoss;
+
+    public GeneralLearnerBaseUDTF() {
+        this(true);
+    }
+
+    public GeneralLearnerBaseUDTF(boolean enableNewModel) {
+        super(enableNewModel);
+        this.optimizerOptions = OptimizerOptions.create();
+    }
+
+    abstract protected String getLossOptionDescription();
+
+    abstract protected LossType getDefaultLossType();
+
+    abstract protected void checkLossFunction(LossFunction lossFunction) throws UDFArgumentException;
+
+    abstract protected void checkTargetValue(float target) throws UDFArgumentException;
+
+    abstract protected void train(@Nonnull final FeatureValue[] features, final float target);
+
+    @Override
+    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        if (argOIs.length < 2) {
+            throw new UDFArgumentException(
+                "_FUNC_ takes 2 arguments: List<Int|BigInt|Text> features, float target [, constant string options]");
+        }
+        this.featureInputOI = processFeaturesOI(argOIs[0]);
+        this.targetOI = HiveUtils.asDoubleCompatibleOI(argOIs[1]);
+
+        processOptions(argOIs);
+
+        PrimitiveObjectInspector featureOutputOI = dense_model ? PrimitiveObjectInspectorFactory.javaIntObjectInspector
+                : featureInputOI;
+        this.model = createModel();
+        if (preloadedModelFile != null) {
+            loadPredictionModel(model, preloadedModelFile, featureOutputOI);
+        }
+
+        try {
+            this.optimizer = createOptimizer(optimizerOptions);
+        } catch (Throwable e) {
+            throw new UDFArgumentException(e.getMessage());
+        }
+
+        this.count = 0;
+        this.sampled = 0;
+        this.cumLoss = 0.f;
+
+        return getReturnOI(featureOutputOI);
+    }
+
+    @Override
+    protected Options getOptions() {
+        Options opts = super.getOptions();
+        opts.addOption("loss", "loss_function", true, getLossOptionDescription());
+        OptimizerOptions.setup(opts);
+        return opts;
+    }
+
+    @Override
+    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
+        CommandLine cl = super.processOptions(argOIs);
+
+        LossFunction lossFunction = LossFunctions.getLossFunction(getDefaultLossType());
+        if (cl.hasOption("loss_function")) {
+            try {
+                lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
+            } catch (Throwable e) {
+                throw new UDFArgumentException(e.getMessage());
+            }
+        }
+        checkLossFunction(lossFunction);
+        this.lossFunction = lossFunction;
+
+        OptimizerOptions.propcessOptions(cl, optimizerOptions);
+
+        return cl;
+    }
+
+    protected PrimitiveObjectInspector processFeaturesOI(ObjectInspector arg)
+            throws UDFArgumentException {
+        this.featureListOI = (ListObjectInspector) arg;
+        ObjectInspector featureRawOI = featureListOI.getListElementObjectInspector();
+        HiveUtils.validateFeatureOI(featureRawOI);
+        this.parseFeature = HiveUtils.isStringOI(featureRawOI);
+        return HiveUtils.asPrimitiveObjectInspector(featureRawOI);
+    }
+
+    protected StructObjectInspector getReturnOI(ObjectInspector featureOutputOI) {
+        ArrayList<String> fieldNames = new ArrayList<String>();
+        ArrayList<ObjectInspector> fieldOIs = new ArrayList<ObjectInspector>();
+
+        fieldNames.add("feature");
+        ObjectInspector featureOI = ObjectInspectorUtils.getStandardObjectInspector(featureOutputOI);
+        fieldOIs.add(featureOI);
+        fieldNames.add("weight");
+        fieldOIs.add(PrimitiveObjectInspectorFactory.writableFloatObjectInspector);
+        if (useCovariance()) {
+            fieldNames.add("covar");
+            fieldOIs.add(PrimitiveObjectInspectorFactory.writableFloatObjectInspector);
+        }
+
+        return ObjectInspectorFactory.getStandardStructObjectInspector(fieldNames, fieldOIs);
+    }
+
+    @Override
+    public void process(Object[] args) throws HiveException {
+        if (is_mini_batch && accumulated == null) {
+            this.accumulated = new HashMap<Object, FloatAccumulator>(1024);
+        }
+
+        List<?> features = (List<?>) featureListOI.getList(args[0]);
+        FeatureValue[] featureVector = parseFeatures(features);
+        if (featureVector == null) {
+            return;
+        }
+        float target = PrimitiveObjectInspectorUtils.getFloat(args[1], targetOI);
+        checkTargetValue(target);
+
+        count++;
+
+        train(featureVector, target);
+    }
+
+    @Nullable
+    public final FeatureValue[] parseFeatures(@Nonnull final List<?> features) {
+        final int size = features.size();
+        if (size == 0) {
+            return null;
+        }
+
+        final ObjectInspector featureInspector = featureListOI.getListElementObjectInspector();
+        final FeatureValue[] featureVector = new FeatureValue[size];
+        for (int i = 0; i < size; i++) {
+            Object f = features.get(i);
+            if (f == null) {
+                continue;
+            }
+            final FeatureValue fv;
+            if (parseFeature) {
+                fv = FeatureValue.parse(f);
+            } else {
+                Object k = ObjectInspectorUtils.copyToStandardObject(f, featureInspector);
+                fv = new FeatureValue(k, 1.f);
+            }
+            featureVector[i] = fv;
+        }
+        return featureVector;
+    }
+
+    public float predict(@Nonnull final FeatureValue[] features) {
+        float score = 0.f;
+        for (FeatureValue f : features) {// a += w[i] * x[i]
+            if (f == null) {
+                continue;
+            }
+            final Object k = f.getFeature();
+            final float v = f.getValueAsFloat();
+
+            float old_w = model.getWeight(k);
+            if (old_w != 0f) {
+                score += (old_w * v);
+            }
+        }
+        return score;
+    }
+
+    protected void update(@Nonnull final FeatureValue[] features, final float target,
+            final float predicted) {
+        this.cumLoss += lossFunction.loss(predicted, target); // retain cumulative loss to check convergence
+        float dloss = lossFunction.dloss(predicted, target);
+        if (is_mini_batch) {
+            accumulateUpdate(features, dloss);
+
+            if (sampled >= mini_batch_size) {
+                batchUpdate();
+            }
+        } else {
+            onlineUpdate(features, dloss);
+        }
+        optimizer.proceedStep();
+    }
+
+    protected void accumulateUpdate(@Nonnull final FeatureValue[] features, final float dloss) {
+        for (FeatureValue f : features) {
+            Object feature = f.getFeature();
+            float xi = f.getValueAsFloat();
+            float weight = model.getWeight(feature);
+
+            // compute new weight, but still not set to the model
+            float new_weight = optimizer.update(feature, weight, dloss * xi);
+
+            // (w_i - eta * delta_1) + (w_i - eta * delta_2) + ... + (w_i - eta * delta_M)
+            FloatAccumulator acc = accumulated.get(feature);
+            if (acc == null) {
+                acc = new FloatAccumulator(new_weight);
+                accumulated.put(feature, acc);
+            } else {
+                acc.add(new_weight);
+            }
+        }
+        sampled++;
+    }
+
+    protected void batchUpdate() {
+        if (accumulated.isEmpty()) {
+            this.sampled = 0;
+            return;
+        }
+
+        for (Map.Entry<Object, FloatAccumulator> e : accumulated.entrySet()) {
+            Object feature = e.getKey();
+            FloatAccumulator v = e.getValue();
+            float new_weight = v.get(); // w_i - (eta / M) * (delta_1 + delta_2 + ... + delta_M)
+            model.setWeight(feature, new_weight);
+        }
+
+        accumulated.clear();
+        this.sampled = 0;
+    }
+
+    protected void onlineUpdate(@Nonnull final FeatureValue[] features, float dloss) {
+        for (FeatureValue f : features) {
+            Object feature = f.getFeature();
+            float xi = f.getValueAsFloat();
+            float weight = model.getWeight(feature);
+            float new_weight = optimizer.update(feature, weight, dloss * xi);
+            model.setWeight(feature, new_weight);
+        }
+    }
+
+    @Override
+    public final void close() throws HiveException {
+        super.close();
+        if (model != null) {
+            if (accumulated != null) { // Update model with accumulated delta
+                batchUpdate();
+                this.accumulated = null;
+            }
+            int numForwarded = 0;
+            if (useCovariance()) {
+                final WeightValueWithCovar probe = new WeightValueWithCovar();
+                final Object[] forwardMapObj = new Object[3];
+                final FloatWritable fv = new FloatWritable();
+                final FloatWritable cov = new FloatWritable();
+                final IMapIterator<Object, IWeightValue> itor = model.entries();
+                while (itor.next() != -1) {
+                    itor.getValue(probe);
+                    if (!probe.isTouched()) {
+                        continue; // skip outputting untouched weights
+                    }
+                    Object k = itor.getKey();
+                    fv.set(probe.get());
+                    cov.set(probe.getCovariance());
+                    forwardMapObj[0] = k;
+                    forwardMapObj[1] = fv;
+                    forwardMapObj[2] = cov;
+                    forward(forwardMapObj);
+                    numForwarded++;
+                }
+            } else {
+                final WeightValue probe = new WeightValue();
+                final Object[] forwardMapObj = new Object[2];
+                final FloatWritable fv = new FloatWritable();
+                final IMapIterator<Object, IWeightValue> itor = model.entries();
+                while (itor.next() != -1) {
+                    itor.getValue(probe);
+                    if (!probe.isTouched()) {
+                        continue; // skip outputting untouched weights
+                    }
+                    Object k = itor.getKey();
+                    fv.set(probe.get());
+                    forwardMapObj[0] = k;
+                    forwardMapObj[1] = fv;
+                    forward(forwardMapObj);
+                    numForwarded++;
+                }
+            }
+            long numMixed = model.getNumMixed();
+            this.model = null;
+            logger.info("Trained a prediction model using " + count + " training examples"
+                    + (numMixed > 0 ? "( numMixed: " + numMixed + " )" : ""));
+            logger.info("Forwarded the prediction model of " + numForwarded + " rows");
+        }
+    }
+
+    @VisibleForTesting
+    public float getCumulativeLoss() {
+        return cumLoss;
+    }
+
+    @VisibleForTesting
+    public void resetCumulativeLoss() {
+        this.cumLoss = 0.f;
+    }
+
+}

--- a/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
@@ -84,7 +84,8 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
 
     abstract protected LossType getDefaultLossType();
 
-    abstract protected void checkLossFunction(LossFunction lossFunction) throws UDFArgumentException;
+    abstract protected void checkLossFunction(LossFunction lossFunction)
+            throws UDFArgumentException;
 
     abstract protected void checkTargetValue(float target) throws UDFArgumentException;
 

--- a/core/src/main/java/hivemall/LearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/LearnerBaseUDTF.java
@@ -25,6 +25,9 @@ import hivemall.model.DenseModel;
 import hivemall.model.PredictionModel;
 import hivemall.model.SpaceEfficientDenseModel;
 import hivemall.model.SparseModel;
+import hivemall.model.NewDenseModel;
+import hivemall.model.NewSparseModel;
+import hivemall.model.NewSpaceEfficientDenseModel;
 import hivemall.model.SynchronizedModelWrapper;
 import hivemall.model.WeightValue;
 import hivemall.model.WeightValue.WeightValueWithCovar;
@@ -189,6 +192,36 @@ public abstract class LearnerBaseUDTF extends UDTFWithOptions {
             logger.info("Build a sparse model with initial with " + initModelSize
                     + " initial dimensions");
             model = new SparseModel(initModelSize, useCovar);
+        }
+        if (mixConnectInfo != null) {
+            model.configureClock();
+            model = new SynchronizedModelWrapper(model);
+            MixClient client = configureMixClient(mixConnectInfo, label, model);
+            model.configureMix(client, mixCancel);
+            this.mixClient = client;
+        }
+        assert (model != null);
+        return model;
+    }
+
+    protected PredictionModel createNewModel(String label) {
+        PredictionModel model;
+        final boolean useCovar = useCovariance();
+        if (dense_model) {
+            if (disable_halffloat == false && model_dims > 16777216) {
+                logger.info("Build a space efficient dense model with " + model_dims
+                        + " initial dimensions" + (useCovar ? " w/ covariances" : ""));
+                model = new NewSpaceEfficientDenseModel(model_dims, useCovar);
+            } else {
+                logger.info("Build a dense model with initial with " + model_dims
+                        + " initial dimensions" + (useCovar ? " w/ covariances" : ""));
+                model = new NewDenseModel(model_dims, useCovar);
+            }
+        } else {
+            int initModelSize = getInitialModelSize();
+            logger.info("Build a sparse model with initial with " + initModelSize
+                    + " initial dimensions");
+            model = new NewSparseModel(initModelSize, useCovar);
         }
         if (mixConnectInfo != null) {
             model.configureClock();

--- a/core/src/main/java/hivemall/LearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/LearnerBaseUDTF.java
@@ -28,6 +28,9 @@ import hivemall.model.SparseModel;
 import hivemall.model.SynchronizedModelWrapper;
 import hivemall.model.WeightValue;
 import hivemall.model.WeightValue.WeightValueWithCovar;
+import hivemall.optimizer.DenseOptimizerFactory;
+import hivemall.optimizer.Optimizer;
+import hivemall.optimizer.SparseOptimizerFactory;
 import hivemall.utils.datetime.StopWatch;
 import hivemall.utils.hadoop.HadoopUtils;
 import hivemall.utils.hadoop.HiveUtils;
@@ -38,6 +41,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -195,6 +199,24 @@ public abstract class LearnerBaseUDTF extends UDTFWithOptions {
         }
         assert (model != null);
         return model;
+    }
+
+    // If a model implements a optimizer, it must override this
+    protected Map<String, String> getOptimzierOptions() {
+        return null;
+    }
+
+    protected Optimizer createOptimizer() {
+        assert(!useCovariance());
+        final Map<String, String> options = getOptimzierOptions();
+        if(options != null) {
+            if (dense_model) {
+                return DenseOptimizerFactory.create(model_dims, options);
+            } else {
+                return SparseOptimizerFactory.create(model_dims, options);
+            }
+        }
+        return null;
     }
 
     protected MixClient configureMixClient(String connectURIs, String label, PredictionModel model) {

--- a/core/src/main/java/hivemall/annotations/InternalAPI.java
+++ b/core/src/main/java/hivemall/annotations/InternalAPI.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotate program elements that might be changed in the future release.
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR})
+@Documented
+public @interface InternalAPI {
+}

--- a/core/src/main/java/hivemall/annotations/Since.java
+++ b/core/src/main/java/hivemall/annotations/Since.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+public @interface Since {
+    String version();
+}

--- a/core/src/main/java/hivemall/anomaly/ChangeFinderUDF.java
+++ b/core/src/main/java/hivemall/anomaly/ChangeFinderUDF.java
@@ -19,6 +19,7 @@
 package hivemall.anomaly;
 
 import hivemall.UDFWithOptions;
+import hivemall.annotations.Since;
 import hivemall.utils.collections.DoubleRingBuffer;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.lang.Preconditions;
@@ -51,6 +52,7 @@ import org.apache.hadoop.io.BooleanWritable;
                 + " - Returns outlier/change-point scores and decisions using ChangeFinder."
                 + " It will return a tuple <double outlier_score, double changepoint_score [, boolean is_anomaly [, boolean is_changepoint]]")
 @UDFType(deterministic = false, stateful = true)
+@Since(version="0.5-rc.1")
 public final class ChangeFinderUDF extends UDFWithOptions {
 
     private transient Parameters _params;

--- a/core/src/main/java/hivemall/anomaly/SingularSpectrumTransformUDF.java
+++ b/core/src/main/java/hivemall/anomaly/SingularSpectrumTransformUDF.java
@@ -19,6 +19,7 @@
 package hivemall.anomaly;
 
 import hivemall.UDFWithOptions;
+import hivemall.annotations.Since;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.lang.Preconditions;
 import hivemall.utils.lang.Primitives;
@@ -58,6 +59,7 @@ import org.apache.hadoop.io.BooleanWritable;
                 + " - Returns change-point scores and decisions using Singular Spectrum Transformation (SST)."
                 + " It will return a tuple <double changepoint_score [, boolean is_changepoint]>")
 @UDFType(deterministic = false, stateful = true)
+@Since(version="0.5-rc.1")
 public final class SingularSpectrumTransformUDF extends UDFWithOptions {
 
     private transient Parameters _params;

--- a/core/src/main/java/hivemall/classifier/AROWClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/AROWClassifierUDTF.java
@@ -18,11 +18,11 @@
  */
 package hivemall.classifier;
 
-import hivemall.optimizer.LossFunctions;
 import hivemall.model.FeatureValue;
 import hivemall.model.IWeightValue;
 import hivemall.model.PredictionResult;
 import hivemall.model.WeightValue.WeightValueWithCovar;
+import hivemall.optimizer.LossFunctions;
 
 import javax.annotation.Nonnull;
 

--- a/core/src/main/java/hivemall/classifier/AROWClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/AROWClassifierUDTF.java
@@ -18,7 +18,7 @@
  */
 package hivemall.classifier;
 
-import hivemall.common.LossFunctions;
+import hivemall.optimizer.LossFunctions;
 import hivemall.model.FeatureValue;
 import hivemall.model.IWeightValue;
 import hivemall.model.PredictionResult;

--- a/core/src/main/java/hivemall/classifier/AdaGradRDAUDTF.java
+++ b/core/src/main/java/hivemall/classifier/AdaGradRDAUDTF.java
@@ -18,124 +18,13 @@
  */
 package hivemall.classifier;
 
-import hivemall.common.LossFunctions;
-import hivemall.model.FeatureValue;
-import hivemall.model.IWeightValue;
-import hivemall.model.WeightValue.WeightValueParamsF2;
-import hivemall.utils.lang.Primitives;
+@Deprecated
+public final class AdaGradRDAUDTF extends GeneralClassifierUDTF {
 
-import javax.annotation.Nonnull;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
-import org.apache.hadoop.hive.ql.exec.Description;
-import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-
-@Description(name = "train_adagrad_rda",
-        value = "_FUNC_(list<string|int|bigint> features, int label [, const string options])"
-                + " - Returns a relation consists of <string|int|bigint feature, float weight>",
-        extended = "Build a prediction model by Adagrad+RDA regularization binary classifier")
-public final class AdaGradRDAUDTF extends BinaryOnlineClassifierUDTF {
-
-    private float eta;
-    private float lambda;
-    private float scaling;
-
-    @Override
-    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
-        final int numArgs = argOIs.length;
-        if (numArgs != 2 && numArgs != 3) {
-            throw new UDFArgumentException(
-                "_FUNC_ takes 2 or 3 arguments: List<Text|Int|BitInt> features, int label [, constant string options]");
-        }
-
-        StructObjectInspector oi = super.initialize(argOIs);
-        model.configureParams(true, false, true);
-        return oi;
+    public AdaGradRDAUDTF() {
+        optimizerOptions.put("optimizer", "AdaGrad");
+        optimizerOptions.put("regularization", "RDA");
+        optimizerOptions.put("lambda", "1e-6");
     }
 
-    @Override
-    protected Options getOptions() {
-        Options opts = super.getOptions();
-        opts.addOption("eta", "eta0", true, "The learning rate \\eta [default 0.1]");
-        opts.addOption("lambda", true, "lambda constant of RDA [default: 1E-6f]");
-        opts.addOption("scale", true,
-            "Internal scaling/descaling factor for cumulative weights [default: 100]");
-        return opts;
-    }
-
-    @Override
-    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
-        CommandLine cl = super.processOptions(argOIs);
-        if (cl == null) {
-            this.eta = 0.1f;
-            this.lambda = 1E-6f;
-            this.scaling = 100f;
-        } else {
-            this.eta = Primitives.parseFloat(cl.getOptionValue("eta"), 0.1f);
-            this.lambda = Primitives.parseFloat(cl.getOptionValue("lambda"), 1E-6f);
-            this.scaling = Primitives.parseFloat(cl.getOptionValue("scale"), 100f);
-        }
-        return cl;
-    }
-
-    @Override
-    protected void train(@Nonnull final FeatureValue[] features, final int label) {
-        final float y = label > 0 ? 1.f : -1.f;
-
-        float p = predict(features);
-        float loss = LossFunctions.hingeLoss(p, y); // 1.0 - y * p        
-        if (loss <= 0.f) { // max(0, 1 - y * p)
-            return;
-        }
-        // subgradient => -y * W dot xi
-        update(features, y, count);
-    }
-
-    protected void update(@Nonnull final FeatureValue[] features, final float y, final int t) {
-        for (FeatureValue f : features) {// w[f] += y * x[f]
-            if (f == null) {
-                continue;
-            }
-            Object x = f.getFeature();
-            float xi = f.getValueAsFloat();
-
-            updateWeight(x, xi, y, t);
-        }
-    }
-
-    protected void updateWeight(@Nonnull final Object x, final float xi, final float y,
-            final float t) {
-        final float gradient = -y * xi;
-        final float scaled_gradient = gradient * scaling;
-
-        float scaled_sum_sqgrad = 0.f;
-        float scaled_sum_grad = 0.f;
-        IWeightValue old = model.get(x);
-        if (old != null) {
-            scaled_sum_sqgrad = old.getSumOfSquaredGradients();
-            scaled_sum_grad = old.getSumOfGradients();
-        }
-        scaled_sum_grad += scaled_gradient;
-        scaled_sum_sqgrad += (scaled_gradient * scaled_gradient);
-
-        float sum_grad = scaled_sum_grad * scaling;
-        double sum_sqgrad = scaled_sum_sqgrad * scaling;
-
-        // sign(u_{t,i})
-        float sign = (sum_grad > 0.f) ? 1.f : -1.f;
-        // |u_{t,i}|/t - \lambda
-        float meansOfGradients = sign * sum_grad / t - lambda;
-        if (meansOfGradients < 0.f) {
-            // x_{t,i} = 0
-            model.delete(x);
-        } else {
-            // x_{t,i} = -sign(u_{t,i}) * \frac{\eta t}{\sqrt{G_{t,ii}}}(|u_{t,i}|/t - \lambda)
-            float weight = -1.f * sign * eta * t * meansOfGradients / (float) Math.sqrt(sum_sqgrad);
-            IWeightValue new_w = new WeightValueParamsF2(weight, scaled_sum_sqgrad, scaled_sum_grad);
-            model.set(x, new_w);
-        }
-    }
 }

--- a/core/src/main/java/hivemall/classifier/AdaGradRDAUDTF.java
+++ b/core/src/main/java/hivemall/classifier/AdaGradRDAUDTF.java
@@ -18,13 +18,128 @@
  */
 package hivemall.classifier;
 
-@Deprecated
-public final class AdaGradRDAUDTF extends GeneralClassifierUDTF {
+import hivemall.model.FeatureValue;
+import hivemall.model.IWeightValue;
+import hivemall.model.WeightValue.WeightValueParamsF2;
+import hivemall.optimizer.LossFunctions;
+import hivemall.utils.lang.Primitives;
 
-    public AdaGradRDAUDTF() {
-        optimizerOptions.put("optimizer", "AdaGrad");
-        optimizerOptions.put("regularization", "RDA");
-        optimizerOptions.put("lambda", "1e-6");
+import javax.annotation.Nonnull;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+
+/**
+ * @deprecated Use {@link hivemall.classifier.GeneralClassifierUDTF} instead
+ */
+@Deprecated
+@Description(name = "train_adagrad_rda",
+        value = "_FUNC_(list<string|int|bigint> features, int label [, const string options])"
+                + " - Returns a relation consists of <string|int|bigint feature, float weight>",
+        extended = "Build a prediction model by Adagrad+RDA regularization binary classifier")
+public final class AdaGradRDAUDTF extends BinaryOnlineClassifierUDTF {
+
+    private float eta;
+    private float lambda;
+    private float scaling;
+
+    @Override
+    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        final int numArgs = argOIs.length;
+        if (numArgs != 2 && numArgs != 3) {
+            throw new UDFArgumentException(
+                "_FUNC_ takes 2 or 3 arguments: List<Text|Int|BitInt> features, int label [, constant string options]");
+        }
+
+        StructObjectInspector oi = super.initialize(argOIs);
+        model.configureParams(true, false, true);
+        return oi;
     }
 
+    @Override
+    protected Options getOptions() {
+        Options opts = super.getOptions();
+        opts.addOption("eta", "eta0", true, "The learning rate \\eta [default 0.1]");
+        opts.addOption("lambda", true, "lambda constant of RDA [default: 1E-6f]");
+        opts.addOption("scale", true,
+            "Internal scaling/descaling factor for cumulative weights [default: 100]");
+        return opts;
+    }
+
+    @Override
+    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
+        CommandLine cl = super.processOptions(argOIs);
+        if (cl == null) {
+            this.eta = 0.1f;
+            this.lambda = 1E-6f;
+            this.scaling = 100f;
+        } else {
+            this.eta = Primitives.parseFloat(cl.getOptionValue("eta"), 0.1f);
+            this.lambda = Primitives.parseFloat(cl.getOptionValue("lambda"), 1E-6f);
+            this.scaling = Primitives.parseFloat(cl.getOptionValue("scale"), 100f);
+        }
+        return cl;
+    }
+
+    @Override
+    protected void train(@Nonnull final FeatureValue[] features, final int label) {
+        final float y = label > 0 ? 1.f : -1.f;
+
+        float p = predict(features);
+        float loss = LossFunctions.hingeLoss(p, y); // 1.0 - y * p        
+        if (loss <= 0.f) { // max(0, 1 - y * p)
+            return;
+        }
+        // subgradient => -y * W dot xi
+        update(features, y, count);
+    }
+
+    protected void update(@Nonnull final FeatureValue[] features, final float y, final int t) {
+        for (FeatureValue f : features) {// w[f] += y * x[f]
+            if (f == null) {
+                continue;
+            }
+            Object x = f.getFeature();
+            float xi = f.getValueAsFloat();
+
+            updateWeight(x, xi, y, t);
+        }
+    }
+
+    protected void updateWeight(@Nonnull final Object x, final float xi, final float y,
+            final float t) {
+        final float gradient = -y * xi;
+        final float scaled_gradient = gradient * scaling;
+
+        float scaled_sum_sqgrad = 0.f;
+        float scaled_sum_grad = 0.f;
+        IWeightValue old = model.get(x);
+        if (old != null) {
+            scaled_sum_sqgrad = old.getSumOfSquaredGradients();
+            scaled_sum_grad = old.getSumOfGradients();
+        }
+        scaled_sum_grad += scaled_gradient;
+        scaled_sum_sqgrad += (scaled_gradient * scaled_gradient);
+
+        float sum_grad = scaled_sum_grad * scaling;
+        double sum_sqgrad = scaled_sum_sqgrad * scaling;
+
+        // sign(u_{t,i})
+        float sign = (sum_grad > 0.f) ? 1.f : -1.f;
+        // |u_{t,i}|/t - \lambda
+        float meansOfGradients = sign * sum_grad / t - lambda;
+        if (meansOfGradients < 0.f) {
+            // x_{t,i} = 0
+            model.delete(x);
+        } else {
+            // x_{t,i} = -sign(u_{t,i}) * \frac{\eta t}{\sqrt{G_{t,ii}}}(|u_{t,i}|/t - \lambda)
+            float weight = -1.f * sign * eta * t * meansOfGradients / (float) Math.sqrt(sum_sqgrad);
+            IWeightValue new_w = new WeightValueParamsF2(weight, scaled_sum_sqgrad, scaled_sum_grad);
+            model.set(x, new_w);
+        }
+    }
 }

--- a/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
@@ -19,13 +19,13 @@
 package hivemall.classifier;
 
 import hivemall.LearnerBaseUDTF;
+import hivemall.annotations.VisibleForTesting;
 import hivemall.model.FeatureValue;
 import hivemall.model.IWeightValue;
 import hivemall.model.PredictionModel;
 import hivemall.model.PredictionResult;
 import hivemall.model.WeightValue;
 import hivemall.model.WeightValue.WeightValueWithCovar;
-import hivemall.optimizer.Optimizer;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.hadoop.HiveUtils;
 
@@ -57,17 +57,14 @@ public abstract class BinaryOnlineClassifierUDTF extends LearnerBaseUDTF {
     private boolean parseFeature;
 
     protected PredictionModel model;
-    protected Optimizer optimizerImpl;
     protected int count;
 
-    private boolean enableNewModel;
-
     public BinaryOnlineClassifierUDTF() {
-        this.enableNewModel = false;
+        this(false);
     }
-
+    
     public BinaryOnlineClassifierUDTF(boolean enableNewModel) {
-        this.enableNewModel = enableNewModel;
+        super(enableNewModel);
     }
 
     @Override
@@ -88,7 +85,6 @@ public abstract class BinaryOnlineClassifierUDTF extends LearnerBaseUDTF {
         if (preloadedModelFile != null) {
             loadPredictionModel(model, preloadedModelFile, featureOutputOI);
         }
-        this.optimizerImpl = createOptimizer();
 
         this.count = 0;
         return getReturnOI(featureOutputOI);
@@ -164,7 +160,7 @@ public abstract class BinaryOnlineClassifierUDTF extends LearnerBaseUDTF {
         assert (label == -1 || label == 0 || label == 1) : label;
     }
 
-    //@VisibleForTesting
+    @VisibleForTesting
     void train(List<?> features, int label) {
         FeatureValue[] featureVector = parseFeatures(features);
         train(featureVector, label);

--- a/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
@@ -25,6 +25,7 @@ import hivemall.model.PredictionModel;
 import hivemall.model.PredictionResult;
 import hivemall.model.WeightValue;
 import hivemall.model.WeightValue.WeightValueWithCovar;
+import hivemall.optimizer.Optimizer;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.hadoop.HiveUtils;
 
@@ -56,6 +57,7 @@ public abstract class BinaryOnlineClassifierUDTF extends LearnerBaseUDTF {
     private boolean parseFeature;
 
     protected PredictionModel model;
+    protected Optimizer optimizerImpl;
     protected int count;
 
     @Override
@@ -76,6 +78,7 @@ public abstract class BinaryOnlineClassifierUDTF extends LearnerBaseUDTF {
         if (preloadedModelFile != null) {
             loadPredictionModel(model, preloadedModelFile, featureOutputOI);
         }
+        this.optimizerImpl = createOptimizer();
 
         this.count = 0;
         return getReturnOI(featureOutputOI);

--- a/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
@@ -62,7 +62,7 @@ public abstract class BinaryOnlineClassifierUDTF extends LearnerBaseUDTF {
     public BinaryOnlineClassifierUDTF() {
         this(false);
     }
-    
+
     public BinaryOnlineClassifierUDTF(boolean enableNewModel) {
         super(enableNewModel);
     }

--- a/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
@@ -279,7 +279,7 @@ public abstract class BinaryOnlineClassifierUDTF extends LearnerBaseUDTF {
         throw new UnsupportedOperationException();
     }
 
-        @Override
+    @Override
     public void close() throws HiveException {
         super.close();
         if (model != null) {

--- a/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/BinaryOnlineClassifierUDTF.java
@@ -60,6 +60,16 @@ public abstract class BinaryOnlineClassifierUDTF extends LearnerBaseUDTF {
     protected Optimizer optimizerImpl;
     protected int count;
 
+    private boolean enableNewModel;
+
+    public BinaryOnlineClassifierUDTF() {
+        this.enableNewModel = false;
+    }
+
+    public BinaryOnlineClassifierUDTF(boolean enableNewModel) {
+        this.enableNewModel = enableNewModel;
+    }
+
     @Override
     public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
         if (argOIs.length < 2) {

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -18,105 +18,96 @@
  */
 package hivemall.classifier;
 
-import java.util.HashMap;
+import hivemall.annotations.Since;
+import hivemall.model.FeatureValue;
+import hivemall.optimizer.LossFunctions;
+import hivemall.optimizer.Optimizer;
+import hivemall.optimizer.OptimizerOptions;
+
 import java.util.Map;
+
 import javax.annotation.Nonnull;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 
-import hivemall.optimizer.LossFunctions;
-import hivemall.model.FeatureValue;
-
 /**
- * A general classifier class with replaceable optimization functions.
+ * A general classifier class that can select a loss function and an optimization function.
  */
-public class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
+@Description(name = "train_classifier",
+        value = "_FUNC_(list<string|int|bigint> features, int label [, const string options])"
+                + " - Returns a relation consists of <string|int|bigint feature, float weight>",
+        extended = "Build a prediction model by a generic classifier")
+@Since(version = "0.5-rc.1")
+public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
 
-    protected final Map<String, String> optimizerOptions;
+    private Optimizer optimizer;
+    @Nonnull
+    private final Map<String, String> optimizerOptions;
 
     public GeneralClassifierUDTF() {
-        super(true); // This enables new model interfaces
-        this.optimizerOptions = new HashMap<String, String>();
-        // Set default values
-        optimizerOptions.put("optimizer", "adagrad");
-        optimizerOptions.put("eta", "fixed");
-        optimizerOptions.put("eta0", "1.0");
-        optimizerOptions.put("regularization", "RDA");
-        optimizerOptions.put("lambda", "1e-6");
-        optimizerOptions.put("scale", "100.0");
-        optimizerOptions.put("lambda", "1.0");
+        super(true);
+        this.optimizerOptions = OptimizerOptions.create();
     }
 
     @Override
     public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
-        if(argOIs.length != 2 && argOIs.length != 3) {
+        if (argOIs.length != 2 && argOIs.length != 3) {
             throw new UDFArgumentException(
-                    this.getClass().getSimpleName()
-                  + " takes 2 or 3 arguments: List<Text|Int|BitInt> features, int label "
-                  + "[, constant string options]");
+                "_FUNC_ takes 2 or 3 arguments: List<Text|Int|BitInt> features, int label "
+                        + "[, constant string options]");
         }
-        return super.initialize(argOIs);
+
+        StructObjectInspector outputOI = super.initialize(argOIs);
+
+        if (is_mini_batch) {
+            throw new UDFArgumentException("_FUNC_ does not currently support `-mini_batch` option");
+        }
+
+        this.optimizer = createOptimizer(optimizerOptions);
+        return outputOI;
     }
 
     @Override
     protected Options getOptions() {
         Options opts = super.getOptions();
-        opts.addOption("optimizer", "opt", true, "Optimizer to update weights [default: adagrad+rda]");
-        opts.addOption("eta", "eta0", true, "Initial learning rate [default 1.0]");
-        opts.addOption("lambda", true, "Lambda value of RDA [default: 1e-6f]");
-        opts.addOption("scale", true, "Scaling factor for cumulative weights [100.0]");
-        opts.addOption("regularization", "reg", true, "Regularization type [default not-defined]");
-        opts.addOption("lambda", true, "Regularization term on weights [default 1.0]");
+        OptimizerOptions.setup(opts);
         return opts;
     }
 
     @Override
     protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
-        final CommandLine cl = super.processOptions(argOIs);
-        assert(cl != null);
-        if(cl != null) {
-            for(final String arg : cl.getArgs()) {
-                optimizerOptions.put(arg, cl.getOptionValue(arg));
-            }
-        }
+        CommandLine cl = super.processOptions(argOIs);
+        OptimizerOptions.propcessOptions(cl, optimizerOptions);
         return cl;
-    }
-
-    @Override
-    protected Map<String, String> getOptimzierOptions() {
-        return optimizerOptions;
     }
 
     @Override
     protected void train(@Nonnull final FeatureValue[] features, final int label) {
         float predicted = predict(features);
-        update(features, label > 0 ? 1.f : -1.f, predicted);
+        float y = label > 0 ? 1.f : -1.f;
+        update(features, y, predicted);
     }
 
     @Override
     protected void update(@Nonnull final FeatureValue[] features, final float label,
             final float predicted) {
-        if(is_mini_batch) {
-            throw new UnsupportedOperationException(
-                    this.getClass().getSimpleName() + " supports no `is_mini_batch` mode");
-        } else {
-            float loss = LossFunctions.hingeLoss(predicted, label);
-            if(loss <= 0.f) {
-                return;
-            }
-            for(FeatureValue f : features) {
-                Object feature = f.getFeature();
-                float xi = f.getValueAsFloat();
-                float weight = model.getWeight(feature);
-                float new_weight = optimizerImpl.computeUpdatedValue(feature, weight, -label * xi);
-                model.setWeight(feature, new_weight);
-            }
-            optimizerImpl.proceedStep();
+        float loss = LossFunctions.hingeLoss(predicted, label);
+        if (loss <= 0.f) {
+            return;
         }
+        for (FeatureValue f : features) {
+            Object feature = f.getFeature();
+            float xi = f.getValueAsFloat();
+            float weight = model.getWeight(feature);
+            float new_weight = optimizer.update(feature, weight, -label * xi);
+            model.setWeight(feature, new_weight);
+        }
+        optimizer.proceedStep();
     }
 
 }

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -66,9 +66,6 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
 
         StructObjectInspector outputOI = super.initialize(argOIs);
 
-        if (lossFunction.forRegression()) {
-            throw new UDFArgumentException("The loss function `" + lossFunction + "` is not for binary classification");
-        }
         if (is_mini_batch) {
             throw new UDFArgumentException("_FUNC_ does not currently support `-mini_batch` option");
         }
@@ -86,7 +83,8 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
     protected Options getOptions() {
         Options opts = super.getOptions();
         opts.addOption("loss", "loss_function", true,
-                "Loss function [default: HingeLoss, LogLoss, SquaredHingeLoss, ModifiedHuberLoss]");
+                "Loss function [default: HingeLoss, LogLoss, SquaredHingeLoss, ModifiedHuberLoss, "
+                + "SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss]");
         OptimizerOptions.setup(opts);
         return opts;
     }

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.classifier;
 

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -73,7 +73,12 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
             throw new UDFArgumentException("_FUNC_ does not currently support `-mini_batch` option");
         }
 
-        this.optimizer = createOptimizer(optimizerOptions);
+        try {
+            this.optimizer = createOptimizer(optimizerOptions);
+        } catch (Throwable e) {
+            throw new UDFArgumentException(e.getMessage());
+        }
+
         return outputOI;
     }
 
@@ -89,10 +94,14 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
     @Override
     protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
         CommandLine cl = super.processOptions(argOIs);
-        if (cl.hasOption("loss_function")) {
-            this.lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
-        } else {
-            this.lossFunction = LossFunctions.getLossFunction("HingeLoss");
+        try {
+            if (cl.hasOption("loss_function")) {
+                this.lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
+            } else {
+                this.lossFunction = LossFunctions.getLossFunction("HingeLoss");
+            }
+        } catch (Throwable e) {
+            throw new UDFArgumentException(e.getMessage());
         }
         OptimizerOptions.propcessOptions(cl, optimizerOptions);
         return cl;

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -22,6 +22,7 @@ import hivemall.annotations.Since;
 import hivemall.model.FeatureValue;
 import hivemall.optimizer.LossFunctions;
 import hivemall.optimizer.LossFunctions.LossFunction;
+import hivemall.optimizer.LossFunctions.LossType;
 import hivemall.optimizer.Optimizer;
 import hivemall.optimizer.OptimizerOptions;
 
@@ -83,8 +84,8 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
     protected Options getOptions() {
         Options opts = super.getOptions();
         opts.addOption("loss", "loss_function", true,
-                "Loss function [default: HingeLoss, LogLoss, SquaredHingeLoss, ModifiedHuberLoss, "
-                + "SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss]");
+            "Loss function [default: HingeLoss, LogLoss, SquaredHingeLoss, ModifiedHuberLoss, "
+                    + "SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss]");
         OptimizerOptions.setup(opts);
         return opts;
     }
@@ -92,14 +93,14 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
     @Override
     protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
         CommandLine cl = super.processOptions(argOIs);
-        try {
-            if (cl.hasOption("loss_function")) {
+        if (cl.hasOption("loss_function")) {
+            try {
                 this.lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
-            } else {
-                this.lossFunction = LossFunctions.getLossFunction("HingeLoss");
+            } catch (Throwable e) {
+                throw new UDFArgumentException(e.getMessage());
             }
-        } catch (Throwable e) {
-            throw new UDFArgumentException(e.getMessage());
+        } else {
+            this.lossFunction = LossFunctions.getLossFunction(LossType.HingeLoss);
         }
         OptimizerOptions.propcessOptions(cl, optimizerOptions);
         return cl;

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -137,6 +137,7 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
             this.loss = lossFunction.loss(predicted, label);
             onlineUpdate(features, dloss);
         }
+        optimizer.proceedStep();
     }
 
     @Override
@@ -175,8 +176,6 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
             model.setWeight(feature, new_weight);
         }
 
-        optimizer.proceedStep();
-
         accumulated.clear();
         this.sampled = 0;
     }
@@ -190,7 +189,6 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
             float new_weight = optimizer.update(feature, weight, dloss * xi);
             model.setWeight(feature, new_weight);
         }
-        optimizer.proceedStep();
     }
 
     @VisibleForTesting

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -39,6 +39,7 @@ public class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
     protected final Map<String, String> optimizerOptions;
 
     public GeneralClassifierUDTF() {
+        super(true); // This enables new model interfaces
         this.optimizerOptions = new HashMap<String, String>();
         // Set default values
         optimizerOptions.put("optimizer", "adagrad");

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -19,6 +19,7 @@
 package hivemall.classifier;
 
 import hivemall.annotations.Since;
+import hivemall.annotations.VisibleForTesting;
 import hivemall.model.FeatureValue;
 import hivemall.optimizer.LossFunctions;
 import hivemall.optimizer.LossFunctions.LossFunction;
@@ -51,6 +52,8 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
     @Nonnull
     private final Map<String, String> optimizerOptions;
     private LossFunction lossFunction;
+
+    private float loss;
 
     public GeneralClassifierUDTF() {
         super(true);
@@ -116,6 +119,8 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
     @Override
     protected void update(@Nonnull final FeatureValue[] features, final float label,
             final float predicted) {
+        this.loss = lossFunction.loss(predicted, label);
+
         float dloss = lossFunction.dloss(predicted, label);
         for (FeatureValue f : features) {
             Object feature = f.getFeature();
@@ -125,6 +130,11 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
             model.setWeight(feature, new_weight);
         }
         optimizer.proceedStep();
+    }
+
+    @VisibleForTesting
+    float getLoss() {
+        return loss;
     }
 
 }

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -1,0 +1,121 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.classifier;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+
+import hivemall.optimizer.LossFunctions;
+import hivemall.model.FeatureValue;
+
+/**
+ * A general classifier class with replaceable optimization functions.
+ */
+public class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
+
+    protected final Map<String, String> optimizerOptions;
+
+    public GeneralClassifierUDTF() {
+        this.optimizerOptions = new HashMap<String, String>();
+        // Set default values
+        optimizerOptions.put("optimizer", "adagrad");
+        optimizerOptions.put("eta", "fixed");
+        optimizerOptions.put("eta0", "1.0");
+        optimizerOptions.put("regularization", "RDA");
+        optimizerOptions.put("lambda", "1e-6");
+        optimizerOptions.put("scale", "100.0");
+        optimizerOptions.put("lambda", "1.0");
+    }
+
+    @Override
+    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        if(argOIs.length != 2 && argOIs.length != 3) {
+            throw new UDFArgumentException(
+                    this.getClass().getSimpleName()
+                  + " takes 2 or 3 arguments: List<Text|Int|BitInt> features, int label "
+                  + "[, constant string options]");
+        }
+        return super.initialize(argOIs);
+    }
+
+    @Override
+    protected Options getOptions() {
+        Options opts = super.getOptions();
+        opts.addOption("optimizer", "opt", true, "Optimizer to update weights [default: adagrad+rda]");
+        opts.addOption("eta", "eta0", true, "Initial learning rate [default 1.0]");
+        opts.addOption("lambda", true, "Lambda value of RDA [default: 1e-6f]");
+        opts.addOption("scale", true, "Scaling factor for cumulative weights [100.0]");
+        opts.addOption("regularization", "reg", true, "Regularization type [default not-defined]");
+        opts.addOption("lambda", true, "Regularization term on weights [default 1.0]");
+        return opts;
+    }
+
+    @Override
+    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
+        final CommandLine cl = super.processOptions(argOIs);
+        assert(cl != null);
+        if(cl != null) {
+            for(final String arg : cl.getArgs()) {
+                optimizerOptions.put(arg, cl.getOptionValue(arg));
+            }
+        }
+        return cl;
+    }
+
+    @Override
+    protected Map<String, String> getOptimzierOptions() {
+        return optimizerOptions;
+    }
+
+    @Override
+    protected void train(@Nonnull final FeatureValue[] features, final int label) {
+        float predicted = predict(features);
+        update(features, label > 0 ? 1.f : -1.f, predicted);
+    }
+
+    @Override
+    protected void update(@Nonnull final FeatureValue[] features, final float label,
+            final float predicted) {
+        if(is_mini_batch) {
+            throw new UnsupportedOperationException(
+                    this.getClass().getSimpleName() + " supports no `is_mini_batch` mode");
+        } else {
+            float loss = LossFunctions.hingeLoss(predicted, label);
+            if(loss <= 0.f) {
+                return;
+            }
+            for(FeatureValue f : features) {
+                Object feature = f.getFeature();
+                float xi = f.getValueAsFloat();
+                float weight = model.getWeight(feature);
+                float new_weight = optimizerImpl.computeUpdatedValue(feature, weight, -label * xi);
+                model.setWeight(feature, new_weight);
+            }
+            optimizerImpl.proceedStep();
+        }
+    }
+
+}

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -117,15 +117,12 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
     @Override
     protected void update(@Nonnull final FeatureValue[] features, final float label,
             final float predicted) {
-        float loss = lossFunction.loss(predicted, label);
-        if (loss <= 0.f) {
-            return;
-        }
+        float dloss = lossFunction.dloss(predicted, label);
         for (FeatureValue f : features) {
             Object feature = f.getFeature();
             float xi = f.getValueAsFloat();
             float weight = model.getWeight(feature);
-            float new_weight = optimizer.update(feature, weight, -label * xi);
+            float new_weight = optimizer.update(feature, weight, dloss * xi);
             model.setWeight(feature, new_weight);
         }
         optimizer.proceedStep();

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -86,7 +86,7 @@ public final class GeneralClassifierUDTF extends BinaryOnlineClassifierUDTF {
     protected Options getOptions() {
         Options opts = super.getOptions();
         opts.addOption("loss", "loss_function", true,
-                "Loss function [default: HingeLoss, LogLoss, SquaredHingeLoss]");
+                "Loss function [default: HingeLoss, LogLoss, SquaredHingeLoss, ModifiedHuberLoss]");
         OptimizerOptions.setup(opts);
         return opts;
     }

--- a/core/src/main/java/hivemall/classifier/KernelExpansionPassiveAggressiveUDTF.java
+++ b/core/src/main/java/hivemall/classifier/KernelExpansionPassiveAggressiveUDTF.java
@@ -20,12 +20,12 @@ package hivemall.classifier;
 
 import hivemall.annotations.Experimental;
 import hivemall.annotations.VisibleForTesting;
-import hivemall.common.LossFunctions;
 import hivemall.model.FeatureValue;
 import hivemall.model.PredictionModel;
 import hivemall.model.PredictionResult;
 import hivemall.utils.collections.maps.Int2FloatOpenHashTable;
 import hivemall.utils.collections.maps.Int2FloatOpenHashTable.IMapIterator;
+import hivemall.optimizer.LossFunctions;
 import hivemall.utils.hashing.HashFunction;
 import hivemall.utils.lang.Preconditions;
 

--- a/core/src/main/java/hivemall/classifier/PassiveAggressiveUDTF.java
+++ b/core/src/main/java/hivemall/classifier/PassiveAggressiveUDTF.java
@@ -18,9 +18,9 @@
  */
 package hivemall.classifier;
 
-import hivemall.optimizer.LossFunctions;
 import hivemall.model.FeatureValue;
 import hivemall.model.PredictionResult;
+import hivemall.optimizer.LossFunctions;
 
 import javax.annotation.Nonnull;
 

--- a/core/src/main/java/hivemall/classifier/PassiveAggressiveUDTF.java
+++ b/core/src/main/java/hivemall/classifier/PassiveAggressiveUDTF.java
@@ -18,7 +18,7 @@
  */
 package hivemall.classifier;
 
-import hivemall.common.LossFunctions;
+import hivemall.optimizer.LossFunctions;
 import hivemall.model.FeatureValue;
 import hivemall.model.PredictionResult;
 

--- a/core/src/main/java/hivemall/classifier/multiclass/MulticlassOnlineClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/multiclass/MulticlassOnlineClassifierUDTF.java
@@ -77,6 +77,14 @@ public abstract class MulticlassOnlineClassifierUDTF extends LearnerBaseUDTF {
     protected Map<Object, PredictionModel> label2model;
     protected int count;
 
+    public MulticlassOnlineClassifierUDTF() {
+        this(false);
+    }
+
+    public MulticlassOnlineClassifierUDTF(boolean enableNewModel) {
+        super(enableNewModel);
+    }
+
     @Override
     public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
         if (argOIs.length < 2) {

--- a/core/src/main/java/hivemall/fm/FMHyperParameters.java
+++ b/core/src/main/java/hivemall/fm/FMHyperParameters.java
@@ -18,8 +18,8 @@
  */
 package hivemall.fm;
 
-import hivemall.common.EtaEstimator;
 import hivemall.fm.FactorizationMachineModel.VInitScheme;
+import hivemall.optimizer.EtaEstimator;
 import hivemall.utils.lang.Primitives;
 
 import javax.annotation.Nonnull;

--- a/core/src/main/java/hivemall/fm/FactorizationMachineModel.java
+++ b/core/src/main/java/hivemall/fm/FactorizationMachineModel.java
@@ -18,7 +18,7 @@
  */
 package hivemall.fm;
 
-import hivemall.common.EtaEstimator;
+import hivemall.optimizer.EtaEstimator;
 import hivemall.utils.lang.NumberUtils;
 import hivemall.utils.math.MathUtils;
 

--- a/core/src/main/java/hivemall/fm/FactorizationMachineUDTF.java
+++ b/core/src/main/java/hivemall/fm/FactorizationMachineUDTF.java
@@ -20,10 +20,10 @@ package hivemall.fm;
 
 import hivemall.UDTFWithOptions;
 import hivemall.common.ConversionState;
-import hivemall.common.EtaEstimator;
-import hivemall.common.LossFunctions;
-import hivemall.common.LossFunctions.LossFunction;
-import hivemall.common.LossFunctions.LossType;
+import hivemall.optimizer.EtaEstimator;
+import hivemall.optimizer.LossFunctions;
+import hivemall.optimizer.LossFunctions.LossFunction;
+import hivemall.optimizer.LossFunctions.LossType;
 import hivemall.fm.FMStringFeatureMapModel.Entry;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.hadoop.HiveUtils;

--- a/core/src/main/java/hivemall/fm/FieldAwareFactorizationMachineModel.java
+++ b/core/src/main/java/hivemall/fm/FieldAwareFactorizationMachineModel.java
@@ -21,7 +21,6 @@ package hivemall.fm;
 import hivemall.fm.FMHyperParameters.FFMHyperParameters;
 import hivemall.utils.collections.arrays.DoubleArray3D;
 import hivemall.utils.collections.lists.IntArrayList;
-import hivemall.optimizer.EtaEstimator;
 import hivemall.utils.lang.NumberUtils;
 
 import java.util.Arrays;

--- a/core/src/main/java/hivemall/fm/FieldAwareFactorizationMachineModel.java
+++ b/core/src/main/java/hivemall/fm/FieldAwareFactorizationMachineModel.java
@@ -21,6 +21,7 @@ package hivemall.fm;
 import hivemall.fm.FMHyperParameters.FFMHyperParameters;
 import hivemall.utils.collections.arrays.DoubleArray3D;
 import hivemall.utils.collections.lists.IntArrayList;
+import hivemall.optimizer.EtaEstimator;
 import hivemall.utils.lang.NumberUtils;
 
 import java.util.Arrays;

--- a/core/src/main/java/hivemall/mf/BPRMatrixFactorizationUDTF.java
+++ b/core/src/main/java/hivemall/mf/BPRMatrixFactorizationUDTF.java
@@ -20,7 +20,7 @@ package hivemall.mf;
 
 import hivemall.UDTFWithOptions;
 import hivemall.common.ConversionState;
-import hivemall.common.EtaEstimator;
+import hivemall.optimizer.EtaEstimator;
 import hivemall.mf.FactorizedModel.RankInitScheme;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.io.FileUtils;

--- a/core/src/main/java/hivemall/mf/MatrixFactorizationSGDUDTF.java
+++ b/core/src/main/java/hivemall/mf/MatrixFactorizationSGDUDTF.java
@@ -18,7 +18,7 @@
  */
 package hivemall.mf;
 
-import hivemall.common.EtaEstimator;
+import hivemall.optimizer.EtaEstimator;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;

--- a/core/src/main/java/hivemall/model/AbstractPredictionModel.java
+++ b/core/src/main/java/hivemall/model/AbstractPredictionModel.java
@@ -18,6 +18,7 @@
  */
 package hivemall.model;
 
+import hivemall.annotations.InternalAPI;
 import hivemall.mix.MixedWeight;
 import hivemall.mix.MixedWeight.WeightWithCovar;
 import hivemall.mix.MixedWeight.WeightWithDelta;
@@ -25,10 +26,12 @@ import hivemall.utils.collections.maps.IntOpenHashMap;
 import hivemall.utils.collections.maps.OpenHashMap;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public abstract class AbstractPredictionModel implements PredictionModel {
     public static final byte BYTE0 = 0;
 
+    @Nullable
     protected ModelUpdateHandler handler;
 
     private long numMixed;
@@ -50,7 +53,7 @@ public abstract class AbstractPredictionModel implements PredictionModel {
     }
 
     @Override
-    public void configureMix(ModelUpdateHandler handler, boolean cancelMixRequest) {
+    public void configureMix(@Nonnull ModelUpdateHandler handler, boolean cancelMixRequest) {
         this.handler = handler;
         this.cancelMixRequest = cancelMixRequest;
         if (cancelMixRequest) {
@@ -184,9 +187,6 @@ public abstract class AbstractPredictionModel implements PredictionModel {
         }
     }
 
-    /**
-     * 
-     */
     @Override
     public void set(@Nonnull Object feature, float weight, float covar, short clock) {
         if (hasCovariance()) {
@@ -197,8 +197,10 @@ public abstract class AbstractPredictionModel implements PredictionModel {
         numMixed++;
     }
 
+    @InternalAPI
     protected abstract void _set(@Nonnull Object feature, float weight, short clock);
 
+    @InternalAPI
     protected abstract void _set(@Nonnull Object feature, float weight, float covar, short clock);
 
 }

--- a/core/src/main/java/hivemall/model/DenseModel.java
+++ b/core/src/main/java/hivemall/model/DenseModel.java
@@ -147,7 +147,7 @@ public final class DenseModel extends AbstractPredictionModel {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends IWeightValue> T get(Object feature) {
+    public <T extends IWeightValue> T get(@Nonnull final Object feature) {
         final int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return null;
@@ -170,7 +170,7 @@ public final class DenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public <T extends IWeightValue> void set(Object feature, T value) {
+    public <T extends IWeightValue> void set(@Nonnull final Object feature, @Nonnull final T value) {
         int i = HiveUtils.parseInt(feature);
         ensureCapacity(i);
         float weight = value.get();
@@ -204,7 +204,7 @@ public final class DenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void delete(@Nonnull Object feature) {
+    public void delete(@Nonnull final Object feature) {
         final int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return;
@@ -226,7 +226,7 @@ public final class DenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public float getWeight(Object feature) {
+    public float getWeight(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return 0f;
@@ -235,12 +235,12 @@ public final class DenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void setWeight(@Nonnull Object feature, float value) {
+    public void setWeight(@Nonnull final Object feature, final float value) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public float getCovariance(Object feature) {
+    public float getCovariance(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return 1f;
@@ -249,7 +249,7 @@ public final class DenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(Object feature, float weight, short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final short clock) {
         int i = ((Integer) feature).intValue();
         ensureCapacity(i);
         weights[i] = weight;
@@ -258,7 +258,8 @@ public final class DenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(Object feature, float weight, float covar, short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final float covar,
+            final short clock) {
         int i = ((Integer) feature).intValue();
         ensureCapacity(i);
         weights[i] = weight;
@@ -273,7 +274,7 @@ public final class DenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public boolean contains(Object feature) {
+    public boolean contains(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return false;
@@ -334,7 +335,7 @@ public final class DenseModel extends AbstractPredictionModel {
         }
 
         @Override
-        public <T extends Copyable<IWeightValue>> void getValue(T probe) {
+        public <T extends Copyable<IWeightValue>> void getValue(@Nonnull final T probe) {
             float w = weights[cursor];
             tmpWeight.value = w;
             float cov = 1.f;

--- a/core/src/main/java/hivemall/model/IWeightValue.java
+++ b/core/src/main/java/hivemall/model/IWeightValue.java
@@ -25,7 +25,7 @@ import javax.annotation.Nonnegative;
 public interface IWeightValue extends Copyable<IWeightValue> {
 
     public enum WeightValueType {
-        NoParams, ParamsF1, ParamsF2, ParamsCovar;
+        NoParams, ParamsF1, ParamsF2, ParamsF3, ParamsCovar;
     }
 
     WeightValueType getType();
@@ -44,9 +44,23 @@ public interface IWeightValue extends Copyable<IWeightValue> {
 
     float getSumOfSquaredGradients();
 
+    void setSumOfSquaredGradients(float value);
+
     float getSumOfSquaredDeltaX();
 
+    void setSumOfSquaredDeltaX(float value);
+
     float getSumOfGradients();
+
+    void setSumOfGradients(float value);
+
+    float getM();
+
+    void setM(float value);
+
+    float getV();
+
+    void setV(float value);
 
     /**
      * @return whether touched in training or not

--- a/core/src/main/java/hivemall/model/NewDenseModel.java
+++ b/core/src/main/java/hivemall/model/NewDenseModel.java
@@ -1,61 +1,51 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Hivemall: Hive scalable Machine Learning Library
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package hivemall.model;
 
-import hivemall.model.WeightValue.WeightValueParamsF1;
-import hivemall.model.WeightValue.WeightValueParamsF2;
+import java.util.Arrays;
+import javax.annotation.Nonnull;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import hivemall.model.WeightValue.WeightValueWithCovar;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.lang.Copyable;
 import hivemall.utils.math.MathUtils;
 
-import java.util.Arrays;
-
-import javax.annotation.Nonnull;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
-public final class DenseModel extends AbstractPredictionModel {
-    private static final Log logger = LogFactory.getLog(DenseModel.class);
+public final class NewDenseModel extends AbstractPredictionModel {
+    private static final Log logger = LogFactory.getLog(NewDenseModel.class);
 
     private int size;
     private float[] weights;
     private float[] covars;
 
-    // optional values for adagrad
-    private float[] sum_of_squared_gradients;
-    // optional value for adadelta
-    private float[] sum_of_squared_delta_x;
-    // optional value for adagrad+rda
-    private float[] sum_of_gradients;
-
     // optional value for MIX
     private short[] clocks;
     private byte[] deltaUpdates;
 
-    public DenseModel(int ndims) {
+    public NewDenseModel(int ndims) {
         this(ndims, false);
     }
 
-    public DenseModel(int ndims, boolean withCovar) {
+    public NewDenseModel(int ndims, boolean withCovar) {
         super();
         int size = ndims + 1;
         this.size = size;
@@ -67,9 +57,6 @@ public final class DenseModel extends AbstractPredictionModel {
         } else {
             this.covars = null;
         }
-        this.sum_of_squared_gradients = null;
-        this.sum_of_squared_delta_x = null;
-        this.sum_of_gradients = null;
         this.clocks = null;
         this.deltaUpdates = null;
     }
@@ -86,17 +73,7 @@ public final class DenseModel extends AbstractPredictionModel {
 
     @Override
     public void configureParams(boolean sum_of_squared_gradients, boolean sum_of_squared_delta_x,
-            boolean sum_of_gradients) {
-        if (sum_of_squared_gradients) {
-            this.sum_of_squared_gradients = new float[size];
-        }
-        if (sum_of_squared_delta_x) {
-            this.sum_of_squared_delta_x = new float[size];
-        }
-        if (sum_of_gradients) {
-            this.sum_of_gradients = new float[size];
-        }
-    }
+            boolean sum_of_gradients) {}
 
     @Override
     public void configureClock() {
@@ -129,16 +106,7 @@ public final class DenseModel extends AbstractPredictionModel {
                 this.covars = Arrays.copyOf(covars, newSize);
                 Arrays.fill(covars, oldSize, newSize, 1.f);
             }
-            if (sum_of_squared_gradients != null) {
-                this.sum_of_squared_gradients = Arrays.copyOf(sum_of_squared_gradients, newSize);
-            }
-            if (sum_of_squared_delta_x != null) {
-                this.sum_of_squared_delta_x = Arrays.copyOf(sum_of_squared_delta_x, newSize);
-            }
-            if (sum_of_gradients != null) {
-                this.sum_of_gradients = Arrays.copyOf(sum_of_gradients, newSize);
-            }
-            if (clocks != null) {
+            if(clocks != null) {
                 this.clocks = Arrays.copyOf(clocks, newSize);
                 this.deltaUpdates = Arrays.copyOf(deltaUpdates, newSize);
             }
@@ -152,17 +120,7 @@ public final class DenseModel extends AbstractPredictionModel {
         if (i >= size) {
             return null;
         }
-        if (sum_of_squared_gradients != null) {
-            if (sum_of_squared_delta_x != null) {
-                return (T) new WeightValueParamsF2(weights[i], sum_of_squared_gradients[i],
-                    sum_of_squared_delta_x[i]);
-            } else if (sum_of_gradients != null) {
-                return (T) new WeightValueParamsF2(weights[i], sum_of_squared_gradients[i],
-                    sum_of_gradients[i]);
-            } else {
-                return (T) new WeightValueParamsF1(weights[i], sum_of_squared_gradients[i]);
-            }
-        } else if (covars != null) {
+        if(covars != null) {
             return (T) new WeightValueWithCovar(weights[i], covars[i]);
         } else {
             return (T) new WeightValue(weights[i]);
@@ -180,15 +138,6 @@ public final class DenseModel extends AbstractPredictionModel {
         if (hasCovar) {
             covar = value.getCovariance();
             covars[i] = covar;
-        }
-        if (sum_of_squared_gradients != null) {
-            sum_of_squared_gradients[i] = value.getSumOfSquaredGradients();
-        }
-        if (sum_of_squared_delta_x != null) {
-            sum_of_squared_delta_x[i] = value.getSumOfSquaredDeltaX();
-        }
-        if (sum_of_gradients != null) {
-            sum_of_gradients[i] = value.getSumOfGradients();
         }
         short clock = 0;
         int delta = 0;
@@ -213,15 +162,6 @@ public final class DenseModel extends AbstractPredictionModel {
         if (covars != null) {
             covars[i] = 1.f;
         }
-        if (sum_of_squared_gradients != null) {
-            sum_of_squared_gradients[i] = 0.f;
-        }
-        if (sum_of_squared_delta_x != null) {
-            sum_of_squared_delta_x[i] = 0.f;
-        }
-        if (sum_of_gradients != null) {
-            sum_of_gradients[i] = 0.f;
-        }
         // avoid clock/delta
     }
 
@@ -235,8 +175,10 @@ public final class DenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void setWeight(@Nonnull Object feature, float value) {
-        throw new UnsupportedOperationException();
+    public void setWeight(Object feature, float value) {
+        int i = HiveUtils.parseInt(feature);
+        ensureCapacity(i);
+        weights[i] = value;
     }
 
     @Override

--- a/core/src/main/java/hivemall/model/NewDenseModel.java
+++ b/core/src/main/java/hivemall/model/NewDenseModel.java
@@ -18,17 +18,18 @@
  */
 package hivemall.model;
 
-import java.util.Arrays;
-import javax.annotation.Nonnull;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
-
 import hivemall.model.WeightValue.WeightValueWithCovar;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.lang.Copyable;
 import hivemall.utils.math.MathUtils;
+
+import java.util.Arrays;
+
+import javax.annotation.Nonnull;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 
 public final class NewDenseModel extends AbstractPredictionModel {
     private static final Log logger = LogFactory.getLog(NewDenseModel.class);
@@ -106,7 +107,7 @@ public final class NewDenseModel extends AbstractPredictionModel {
                 this.covars = Arrays.copyOf(covars, newSize);
                 Arrays.fill(covars, oldSize, newSize, 1.f);
             }
-            if(clocks != null) {
+            if (clocks != null) {
                 this.clocks = Arrays.copyOf(clocks, newSize);
                 this.deltaUpdates = Arrays.copyOf(deltaUpdates, newSize);
             }
@@ -115,12 +116,12 @@ public final class NewDenseModel extends AbstractPredictionModel {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends IWeightValue> T get(Object feature) {
+    public <T extends IWeightValue> T get(@Nonnull final Object feature) {
         final int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return null;
         }
-        if(covars != null) {
+        if (covars != null) {
             return (T) new WeightValueWithCovar(weights[i], covars[i]);
         } else {
             return (T) new WeightValue(weights[i]);
@@ -128,7 +129,7 @@ public final class NewDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public <T extends IWeightValue> void set(Object feature, T value) {
+    public <T extends IWeightValue> void set(@Nonnull final Object feature, @Nonnull final T value) {
         int i = HiveUtils.parseInt(feature);
         ensureCapacity(i);
         float weight = value.get();
@@ -153,7 +154,7 @@ public final class NewDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void delete(@Nonnull Object feature) {
+    public void delete(@Nonnull final Object feature) {
         final int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return;
@@ -166,7 +167,7 @@ public final class NewDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public float getWeight(Object feature) {
+    public float getWeight(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return 0f;
@@ -175,14 +176,14 @@ public final class NewDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void setWeight(Object feature, float value) {
+    public void setWeight(@Nonnull final Object feature, final float value) {
         int i = HiveUtils.parseInt(feature);
         ensureCapacity(i);
         weights[i] = value;
     }
 
     @Override
-    public float getCovariance(Object feature) {
+    public float getCovariance(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return 1f;
@@ -191,7 +192,7 @@ public final class NewDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(Object feature, float weight, short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final short clock) {
         int i = ((Integer) feature).intValue();
         ensureCapacity(i);
         weights[i] = weight;
@@ -200,7 +201,8 @@ public final class NewDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(Object feature, float weight, float covar, short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final float covar,
+            final short clock) {
         int i = ((Integer) feature).intValue();
         ensureCapacity(i);
         weights[i] = weight;
@@ -215,7 +217,7 @@ public final class NewDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public boolean contains(Object feature) {
+    public boolean contains(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return false;
@@ -276,7 +278,7 @@ public final class NewDenseModel extends AbstractPredictionModel {
         }
 
         @Override
-        public <T extends Copyable<IWeightValue>> void getValue(T probe) {
+        public <T extends Copyable<IWeightValue>> void getValue(@Nonnull final T probe) {
             float w = weights[cursor];
             tmpWeight.value = w;
             float cov = 1.f;

--- a/core/src/main/java/hivemall/model/NewDenseModel.java
+++ b/core/src/main/java/hivemall/model/NewDenseModel.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.model;
 

--- a/core/src/main/java/hivemall/model/NewSpaceEfficientDenseModel.java
+++ b/core/src/main/java/hivemall/model/NewSpaceEfficientDenseModel.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.model;
 

--- a/core/src/main/java/hivemall/model/NewSpaceEfficientDenseModel.java
+++ b/core/src/main/java/hivemall/model/NewSpaceEfficientDenseModel.java
@@ -18,6 +18,7 @@
  */
 package hivemall.model;
 
+import hivemall.annotations.InternalAPI;
 import hivemall.model.WeightValue.WeightValueWithCovar;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.hadoop.HiveUtils;
@@ -26,6 +27,7 @@ import hivemall.utils.lang.HalfFloat;
 import hivemall.utils.math.MathUtils;
 
 import java.util.Arrays;
+
 import javax.annotation.Nonnull;
 
 import org.apache.commons.logging.Log;
@@ -103,8 +105,9 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
         return HalfFloat.halfFloatToFloat(covars[i]);
     }
 
+    @InternalAPI
     private void _setWeight(final int i, final float v) {
-        if(Math.abs(v) >= HalfFloat.MAX_FLOAT) {
+        if (Math.abs(v) >= HalfFloat.MAX_FLOAT) {
             throw new IllegalArgumentException("Acceptable maximum weight is "
                     + HalfFloat.MAX_FLOAT + ": " + v);
         }
@@ -129,7 +132,7 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
                 this.covars = Arrays.copyOf(covars, newSize);
                 Arrays.fill(covars, oldSize, newSize, HalfFloat.ONE);
             }
-            if(clocks != null) {
+            if (clocks != null) {
                 this.clocks = Arrays.copyOf(clocks, newSize);
                 this.deltaUpdates = Arrays.copyOf(deltaUpdates, newSize);
             }
@@ -138,13 +141,13 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends IWeightValue> T get(Object feature) {
+    public <T extends IWeightValue> T get(@Nonnull final Object feature) {
         final int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return null;
         }
 
-        if(covars != null) {
+        if (covars != null) {
             return (T) new WeightValueWithCovar(getWeight(i), getCovar(i));
         } else {
             return (T) new WeightValue(getWeight(i));
@@ -152,7 +155,7 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public <T extends IWeightValue> void set(Object feature, T value) {
+    public <T extends IWeightValue> void set(@Nonnull final Object feature, @Nonnull final T value) {
         int i = HiveUtils.parseInt(feature);
         ensureCapacity(i);
         float weight = value.get();
@@ -177,20 +180,20 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void delete(@Nonnull Object feature) {
+    public void delete(@Nonnull final Object feature) {
         final int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return;
         }
         _setWeight(i, 0.f);
-        if(covars != null) {
+        if (covars != null) {
             setCovar(i, 1.f);
         }
         // avoid clock/delta
     }
 
     @Override
-    public float getWeight(Object feature) {
+    public float getWeight(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return 0f;
@@ -199,14 +202,14 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void setWeight(Object feature, float value) {
+    public void setWeight(@Nonnull final Object feature, final float value) {
         int i = HiveUtils.parseInt(feature);
         ensureCapacity(i);
         _setWeight(i, value);
     }
 
     @Override
-    public float getCovariance(Object feature) {
+    public float getCovariance(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return 1f;
@@ -215,7 +218,7 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(Object feature, float weight, short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final short clock) {
         int i = ((Integer) feature).intValue();
         ensureCapacity(i);
         _setWeight(i, weight);
@@ -224,7 +227,8 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(Object feature, float weight, float covar, short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final float covar,
+            final short clock) {
         int i = ((Integer) feature).intValue();
         ensureCapacity(i);
         _setWeight(i, weight);
@@ -239,7 +243,7 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public boolean contains(Object feature) {
+    public boolean contains(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return false;
@@ -300,7 +304,7 @@ public final class NewSpaceEfficientDenseModel extends AbstractPredictionModel {
         }
 
         @Override
-        public <T extends Copyable<IWeightValue>> void getValue(T probe) {
+        public <T extends Copyable<IWeightValue>> void getValue(@Nonnull final T probe) {
             float w = getWeight(cursor);
             tmpWeight.value = w;
             float cov = 1.f;

--- a/core/src/main/java/hivemall/model/NewSparseModel.java
+++ b/core/src/main/java/hivemall/model/NewSparseModel.java
@@ -20,6 +20,7 @@ package hivemall.model;
 
 import hivemall.model.WeightValueWithClock.WeightValueParamsF1Clock;
 import hivemall.model.WeightValueWithClock.WeightValueParamsF2Clock;
+import hivemall.model.WeightValueWithClock.WeightValueParamsF3Clock;
 import hivemall.model.WeightValueWithClock.WeightValueWithCovarClock;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.collections.OpenHashMap;
@@ -73,12 +74,12 @@ public final class NewSparseModel extends AbstractPredictionModel {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends IWeightValue> T get(final Object feature) {
+    public <T extends IWeightValue> T get(@Nonnull final Object feature) {
         return (T) weights.get(feature);
     }
 
     @Override
-    public <T extends IWeightValue> void set(final Object feature, final T value) {
+    public <T extends IWeightValue> void set(@Nonnull final Object feature, @Nonnull final T value) {
         assert (feature != null);
         assert (value != null);
 
@@ -99,11 +100,12 @@ public final class NewSparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void delete(@Nonnull Object feature) {
+    public void delete(@Nonnull final Object feature) {
         weights.remove(feature);
     }
 
-    private IWeightValue wrapIfRequired(final IWeightValue value) {
+    @Nonnull
+    private IWeightValue wrapIfRequired(@Nonnull final IWeightValue value) {
         final IWeightValue wrapper;
         if (clockEnabled) {
             switch (value.getType()) {
@@ -119,6 +121,9 @@ public final class NewSparseModel extends AbstractPredictionModel {
                 case ParamsF2:
                     wrapper = new WeightValueParamsF2Clock(value);
                     break;
+                case ParamsF3:
+                    wrapper = new WeightValueParamsF3Clock(value);
+                    break;
                 default:
                     throw new IllegalStateException("Unexpected value type: " + value.getType());
             }
@@ -129,14 +134,14 @@ public final class NewSparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public float getWeight(final Object feature) {
+    public float getWeight(@Nonnull final Object feature) {
         IWeightValue v = weights.get(feature);
         return v == null ? 0.f : v.get();
     }
 
     @Override
-    public void setWeight(Object feature, float value) {
-        if(weights.containsKey(feature)) {
+    public void setWeight(@Nonnull final Object feature, final float value) {
+        if (weights.containsKey(feature)) {
             IWeightValue weight = weights.get(feature);
             weight.set(value);
         } else {
@@ -147,13 +152,13 @@ public final class NewSparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public float getCovariance(final Object feature) {
+    public float getCovariance(@Nonnull final Object feature) {
         IWeightValue v = weights.get(feature);
         return v == null ? 1.f : v.getCovariance();
     }
 
     @Override
-    protected void _set(final Object feature, final float weight, final short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final short clock) {
         final IWeightValue w = weights.get(feature);
         if (w == null) {
             logger.warn("Previous weight not found: " + feature);
@@ -165,7 +170,7 @@ public final class NewSparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(final Object feature, final float weight, final float covar,
+    protected void _set(@Nonnull final Object feature, final float weight, final float covar,
             final short clock) {
         final IWeightValue w = weights.get(feature);
         if (w == null) {
@@ -184,7 +189,7 @@ public final class NewSparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public boolean contains(final Object feature) {
+    public boolean contains(@Nonnull final Object feature) {
         return weights.containsKey(feature);
     }
 

--- a/core/src/main/java/hivemall/model/NewSparseModel.java
+++ b/core/src/main/java/hivemall/model/NewSparseModel.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.model;
 

--- a/core/src/main/java/hivemall/model/NewSparseModel.java
+++ b/core/src/main/java/hivemall/model/NewSparseModel.java
@@ -1,20 +1,20 @@
 /*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
+ * Hivemall: Hive scalable Machine Learning Library
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package hivemall.model;
 
@@ -22,21 +22,25 @@ import hivemall.model.WeightValueWithClock.WeightValueParamsF1Clock;
 import hivemall.model.WeightValueWithClock.WeightValueParamsF2Clock;
 import hivemall.model.WeightValueWithClock.WeightValueWithCovarClock;
 import hivemall.utils.collections.IMapIterator;
-import hivemall.utils.collections.maps.OpenHashMap;
+import hivemall.utils.collections.OpenHashMap;
 
 import javax.annotation.Nonnull;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-public final class SparseModel extends AbstractPredictionModel {
-    private static final Log logger = LogFactory.getLog(SparseModel.class);
+public final class NewSparseModel extends AbstractPredictionModel {
+    private static final Log logger = LogFactory.getLog(NewSparseModel.class);
 
     private final OpenHashMap<Object, IWeightValue> weights;
     private final boolean hasCovar;
     private boolean clockEnabled;
 
-    public SparseModel(int size, boolean hasCovar) {
+    public NewSparseModel(int size) {
+        this(size, false);
+    }
+
+    public NewSparseModel(int size, boolean hasCovar) {
         super();
         this.weights = new OpenHashMap<Object, IWeightValue>(size);
         this.hasCovar = hasCovar;
@@ -131,8 +135,15 @@ public final class SparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void setWeight(@Nonnull Object feature, float value) {
-        throw new UnsupportedOperationException();
+    public void setWeight(Object feature, float value) {
+        if(weights.containsKey(feature)) {
+            IWeightValue weight = weights.get(feature);
+            weight.set(value);
+        } else {
+            IWeightValue weight = new WeightValue(value);
+            weight.set(value);
+            weights.put(feature, weight);
+        }
     }
 
     @Override

--- a/core/src/main/java/hivemall/model/NewSparseModel.java
+++ b/core/src/main/java/hivemall/model/NewSparseModel.java
@@ -23,7 +23,7 @@ import hivemall.model.WeightValueWithClock.WeightValueParamsF2Clock;
 import hivemall.model.WeightValueWithClock.WeightValueParamsF3Clock;
 import hivemall.model.WeightValueWithClock.WeightValueWithCovarClock;
 import hivemall.utils.collections.IMapIterator;
-import hivemall.utils.collections.OpenHashMap;
+import hivemall.utils.collections.maps.OpenHashMap;
 
 import javax.annotation.Nonnull;
 

--- a/core/src/main/java/hivemall/model/PredictionModel.java
+++ b/core/src/main/java/hivemall/model/PredictionModel.java
@@ -34,9 +34,6 @@ public interface PredictionModel extends MixedModel {
 
     boolean hasCovariance();
 
-    void configureParams(boolean sum_of_squared_gradients, boolean sum_of_squared_delta_x,
-            boolean sum_of_gradients);
-
     void configureClock();
 
     boolean hasClock();
@@ -55,6 +52,8 @@ public interface PredictionModel extends MixedModel {
     <T extends IWeightValue> void set(@Nonnull Object feature, @Nonnull T value);
 
     float getWeight(@Nonnull Object feature);
+
+    void setWeight(@Nonnull Object feature, float value);
 
     float getCovariance(@Nonnull Object feature);
 

--- a/core/src/main/java/hivemall/model/PredictionModel.java
+++ b/core/src/main/java/hivemall/model/PredictionModel.java
@@ -26,9 +26,10 @@ import javax.annotation.Nullable;
 
 public interface PredictionModel extends MixedModel {
 
+    @Nullable
     ModelUpdateHandler getUpdateHandler();
 
-    void configureMix(ModelUpdateHandler handler, boolean cancelMixRequest);
+    void configureMix(@Nonnull ModelUpdateHandler handler, boolean cancelMixRequest);
 
     long getNumMixed();
 

--- a/core/src/main/java/hivemall/model/PredictionModel.java
+++ b/core/src/main/java/hivemall/model/PredictionModel.java
@@ -34,6 +34,9 @@ public interface PredictionModel extends MixedModel {
 
     boolean hasCovariance();
 
+    void configureParams(boolean sum_of_squared_gradients, boolean sum_of_squared_delta_x,
+            boolean sum_of_gradients);
+
     void configureClock();
 
     boolean hasClock();

--- a/core/src/main/java/hivemall/model/SpaceEfficientDenseModel.java
+++ b/core/src/main/java/hivemall/model/SpaceEfficientDenseModel.java
@@ -167,7 +167,7 @@ public final class SpaceEfficientDenseModel extends AbstractPredictionModel {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends IWeightValue> T get(Object feature) {
+    public <T extends IWeightValue> T get(@Nonnull final Object feature) {
         final int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return null;
@@ -190,7 +190,7 @@ public final class SpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public <T extends IWeightValue> void set(Object feature, T value) {
+    public <T extends IWeightValue> void set(@Nonnull final Object feature, @Nonnull final T value) {
         int i = HiveUtils.parseInt(feature);
         ensureCapacity(i);
         float weight = value.get();
@@ -224,7 +224,7 @@ public final class SpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public void delete(@Nonnull Object feature) {
+    public void delete(@Nonnull final Object feature) {
         final int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return;
@@ -246,7 +246,7 @@ public final class SpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public float getWeight(Object feature) {
+    public float getWeight(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return 0f;
@@ -260,7 +260,7 @@ public final class SpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public float getCovariance(Object feature) {
+    public float getCovariance(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return 1f;
@@ -269,7 +269,7 @@ public final class SpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(Object feature, float weight, short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final short clock) {
         int i = ((Integer) feature).intValue();
         ensureCapacity(i);
         setWeight(i, weight);
@@ -278,7 +278,8 @@ public final class SpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(Object feature, float weight, float covar, short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final float covar,
+            final short clock) {
         int i = ((Integer) feature).intValue();
         ensureCapacity(i);
         setWeight(i, weight);
@@ -293,7 +294,7 @@ public final class SpaceEfficientDenseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public boolean contains(Object feature) {
+    public boolean contains(@Nonnull final Object feature) {
         int i = HiveUtils.parseInt(feature);
         if (i >= size) {
             return false;
@@ -354,7 +355,7 @@ public final class SpaceEfficientDenseModel extends AbstractPredictionModel {
         }
 
         @Override
-        public <T extends Copyable<IWeightValue>> void getValue(T probe) {
+        public <T extends Copyable<IWeightValue>> void getValue(@Nonnull final T probe) {
             float w = getWeight(cursor);
             tmpWeight.value = w;
             float cov = 1.f;

--- a/core/src/main/java/hivemall/model/SparseModel.java
+++ b/core/src/main/java/hivemall/model/SparseModel.java
@@ -20,6 +20,7 @@ package hivemall.model;
 
 import hivemall.model.WeightValueWithClock.WeightValueParamsF1Clock;
 import hivemall.model.WeightValueWithClock.WeightValueParamsF2Clock;
+import hivemall.model.WeightValueWithClock.WeightValueParamsF3Clock;
 import hivemall.model.WeightValueWithClock.WeightValueWithCovarClock;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.collections.maps.OpenHashMap;
@@ -69,12 +70,12 @@ public final class SparseModel extends AbstractPredictionModel {
 
     @SuppressWarnings("unchecked")
     @Override
-    public <T extends IWeightValue> T get(final Object feature) {
+    public <T extends IWeightValue> T get(@Nonnull final Object feature) {
         return (T) weights.get(feature);
     }
 
     @Override
-    public <T extends IWeightValue> void set(final Object feature, final T value) {
+    public <T extends IWeightValue> void set(@Nonnull final Object feature, @Nonnull final T value) {
         assert (feature != null);
         assert (value != null);
 
@@ -99,7 +100,8 @@ public final class SparseModel extends AbstractPredictionModel {
         weights.remove(feature);
     }
 
-    private IWeightValue wrapIfRequired(final IWeightValue value) {
+    @Nonnull
+    private IWeightValue wrapIfRequired(@Nonnull final IWeightValue value) {
         final IWeightValue wrapper;
         if (clockEnabled) {
             switch (value.getType()) {
@@ -115,6 +117,9 @@ public final class SparseModel extends AbstractPredictionModel {
                 case ParamsF2:
                     wrapper = new WeightValueParamsF2Clock(value);
                     break;
+                case ParamsF3:
+                    wrapper = new WeightValueParamsF3Clock(value);
+                    break;
                 default:
                     throw new IllegalStateException("Unexpected value type: " + value.getType());
             }
@@ -125,7 +130,7 @@ public final class SparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public float getWeight(final Object feature) {
+    public float getWeight(@Nonnull final Object feature) {
         IWeightValue v = weights.get(feature);
         return v == null ? 0.f : v.get();
     }
@@ -136,13 +141,13 @@ public final class SparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public float getCovariance(final Object feature) {
+    public float getCovariance(@Nonnull final Object feature) {
         IWeightValue v = weights.get(feature);
         return v == null ? 1.f : v.getCovariance();
     }
 
     @Override
-    protected void _set(final Object feature, final float weight, final short clock) {
+    protected void _set(@Nonnull final Object feature, final float weight, final short clock) {
         final IWeightValue w = weights.get(feature);
         if (w == null) {
             logger.warn("Previous weight not found: " + feature);
@@ -154,7 +159,7 @@ public final class SparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    protected void _set(final Object feature, final float weight, final float covar,
+    protected void _set(@Nonnull final Object feature, final float weight, final float covar,
             final short clock) {
         final IWeightValue w = weights.get(feature);
         if (w == null) {
@@ -173,7 +178,7 @@ public final class SparseModel extends AbstractPredictionModel {
     }
 
     @Override
-    public boolean contains(final Object feature) {
+    public boolean contains(@Nonnull final Object feature) {
         return weights.containsKey(feature);
     }
 

--- a/core/src/main/java/hivemall/model/SparseModel.java
+++ b/core/src/main/java/hivemall/model/SparseModel.java
@@ -36,6 +36,10 @@ public final class SparseModel extends AbstractPredictionModel {
     private final boolean hasCovar;
     private boolean clockEnabled;
 
+    public SparseModel(int size) {
+        this(size, false);
+    }
+
     public SparseModel(int size, boolean hasCovar) {
         super();
         this.weights = new OpenHashMap<Object, IWeightValue>(size);
@@ -52,10 +56,6 @@ public final class SparseModel extends AbstractPredictionModel {
     public boolean hasCovariance() {
         return hasCovar;
     }
-
-    @Override
-    public void configureParams(boolean sum_of_squared_gradients, boolean sum_of_squared_delta_x,
-            boolean sum_of_gradients) {}
 
     @Override
     public void configureClock() {
@@ -128,6 +128,18 @@ public final class SparseModel extends AbstractPredictionModel {
     public float getWeight(final Object feature) {
         IWeightValue v = weights.get(feature);
         return v == null ? 0.f : v.get();
+    }
+
+    @Override
+    public void setWeight(Object feature, float value) {
+        if(weights.containsKey(feature)) {
+            IWeightValue weight = weights.get(feature);
+            weight.set(value);
+        } else {
+            IWeightValue weight = new WeightValue(value);
+            weight.set(value);
+            weights.put(feature, weight);
+        }
     }
 
     @Override

--- a/core/src/main/java/hivemall/model/SynchronizedModelWrapper.java
+++ b/core/src/main/java/hivemall/model/SynchronizedModelWrapper.java
@@ -63,6 +63,12 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
+    public void configureParams(boolean sum_of_squared_gradients, boolean sum_of_squared_delta_x,
+            boolean sum_of_gradients) {
+        model.configureParams(sum_of_squared_gradients, sum_of_squared_delta_x, sum_of_gradients);
+    }
+
+    @Override
     public void configureClock() {
         model.configureClock();
     }

--- a/core/src/main/java/hivemall/model/SynchronizedModelWrapper.java
+++ b/core/src/main/java/hivemall/model/SynchronizedModelWrapper.java
@@ -107,7 +107,7 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
-    public boolean contains(Object feature) {
+    public boolean contains(@Nonnull final Object feature) {
         try {
             lock.lock();
             return model.contains(feature);
@@ -117,7 +117,7 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
-    public <T extends IWeightValue> T get(Object feature) {
+    public <T extends IWeightValue> T get(@Nonnull final Object feature) {
         try {
             lock.lock();
             return model.get(feature);
@@ -127,7 +127,7 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
-    public <T extends IWeightValue> void set(Object feature, T value) {
+    public <T extends IWeightValue> void set(@Nonnull final Object feature, @Nonnull final T value) {
         try {
             lock.lock();
             model.set(feature, value);
@@ -137,7 +137,7 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
-    public void delete(@Nonnull Object feature) {
+    public void delete(@Nonnull final Object feature) {
         try {
             lock.lock();
             model.delete(feature);
@@ -147,7 +147,7 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
-    public float getWeight(Object feature) {
+    public float getWeight(@Nonnull final Object feature) {
         try {
             lock.lock();
             return model.getWeight(feature);
@@ -157,7 +157,7 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
-    public void setWeight(Object feature, float value) {
+    public void setWeight(@Nonnull final Object feature, final float value) {
         try {
             lock.lock();
             model.setWeight(feature, value);
@@ -167,7 +167,7 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
-    public float getCovariance(Object feature) {
+    public float getCovariance(@Nonnull final Object feature) {
         try {
             lock.lock();
             return model.getCovariance(feature);
@@ -177,7 +177,8 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
-    public void set(@Nonnull Object feature, float weight, float covar, short clock) {
+    public void set(@Nonnull final Object feature, final float weight, final float covar,
+            final short clock) {
         try {
             lock.lock();
             model.set(feature, weight, covar, clock);

--- a/core/src/main/java/hivemall/model/SynchronizedModelWrapper.java
+++ b/core/src/main/java/hivemall/model/SynchronizedModelWrapper.java
@@ -63,12 +63,6 @@ public final class SynchronizedModelWrapper implements PredictionModel {
     }
 
     @Override
-    public void configureParams(boolean sum_of_squared_gradients, boolean sum_of_squared_delta_x,
-            boolean sum_of_gradients) {
-        model.configureParams(sum_of_squared_gradients, sum_of_squared_delta_x, sum_of_gradients);
-    }
-
-    @Override
     public void configureClock() {
         model.configureClock();
     }
@@ -151,6 +145,16 @@ public final class SynchronizedModelWrapper implements PredictionModel {
         try {
             lock.lock();
             return model.getWeight(feature);
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public void setWeight(Object feature, float value) {
+        try {
+            lock.lock();
+            model.setWeight(feature, value);
         } finally {
             lock.unlock();
         }

--- a/core/src/main/java/hivemall/model/WeightValue.java
+++ b/core/src/main/java/hivemall/model/WeightValue.java
@@ -77,13 +77,48 @@ public class WeightValue implements IWeightValue {
     }
 
     @Override
+    public void setSumOfSquaredGradients(float value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public float getSumOfSquaredDeltaX() {
         return 0.f;
     }
 
     @Override
+    public void setSumOfSquaredDeltaX(float value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public float getSumOfGradients() {
         return 0.f;
+    }
+
+    @Override
+    public void setSumOfGradients(float value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float getM() {
+        return 0.f;
+    }
+
+    @Override
+    public void setM(float value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float getV() {
+        return 0.f;
+    }
+
+    @Override
+    public void setV(float value) {
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -137,7 +172,7 @@ public class WeightValue implements IWeightValue {
     }
 
     public static final class WeightValueParamsF1 extends WeightValue {
-        private final float f1;
+        private float f1;
 
         public WeightValueParamsF1(float weight, float f1) {
             super(weight);
@@ -162,14 +197,19 @@ public class WeightValue implements IWeightValue {
             return f1;
         }
 
+        @Override
+        public void setSumOfSquaredGradients(float value) {
+            this.f1 = value;
+        }
+
     }
 
     /**
      * WeightValue with Sum of Squared Gradients
      */
     public static final class WeightValueParamsF2 extends WeightValue {
-        private final float f1;
-        private final float f2;
+        private float f1;
+        private float f2;
 
         public WeightValueParamsF2(float weight, float f1, float f2) {
             super(weight);
@@ -198,13 +238,129 @@ public class WeightValue implements IWeightValue {
         }
 
         @Override
+        public void setSumOfSquaredGradients(float value) {
+            this.f1 = value;
+        }
+
+        @Override
         public final float getSumOfSquaredDeltaX() {
             return f2;
         }
 
         @Override
+        public void setSumOfSquaredDeltaX(float value) {
+            this.f2 = value;
+        }
+
+        @Override
         public float getSumOfGradients() {
             return f2;
+        }
+
+        @Override
+        public void setSumOfGradients(float value) {
+            this.f2 = value;
+        }
+
+        @Override
+        public float getM() {
+            return f1;
+        }
+
+        @Override
+        public void setM(float value) {
+            this.f1 = value;
+        }
+
+        @Override
+        public float getV() {
+            return f2;
+        }
+
+        @Override
+        public void setV(float value) {
+            this.f2 = value;
+        }
+
+    }
+
+    public static final class WeightValueParamsF3 extends WeightValue {
+        private float f1;
+        private float f2;
+        private float f3;
+
+        public WeightValueParamsF3(float weight, float f1, float f2, float f3) {
+            super(weight);
+            this.f1 = f1;
+            this.f2 = f2;
+            this.f3 = f3;
+        }
+
+        @Override
+        public WeightValueType getType() {
+            return WeightValueType.ParamsF3;
+        }
+
+        @Override
+        public float getFloatParams(@Nonnegative final int i) {
+            if(i == 1) {
+                return f1;
+            } else if(i == 2) {
+                return f2;
+            } else if (i == 3) {
+                return f3;
+            }
+            throw new IllegalArgumentException("getFloatParams(" + i + ") should not be called");
+        }
+
+        @Override
+        public final float getSumOfSquaredGradients() {
+            return f1;
+        }
+
+        @Override
+        public void setSumOfSquaredGradients(float value) {
+            this.f1 = value;
+        }
+
+        @Override
+        public final float getSumOfSquaredDeltaX() {
+            return f2;
+        }
+
+        @Override
+        public void setSumOfSquaredDeltaX(float value) {
+            this.f2 = value;
+        }
+
+        @Override
+        public float getSumOfGradients() {
+            return f3;
+        }
+
+        @Override
+        public void setSumOfGradients(float value) {
+            this.f3 = value;
+        }
+
+        @Override
+        public float getM() {
+            return f1;
+        }
+
+        @Override
+        public void setM(float value) {
+            this.f1 = value;
+        }
+
+        @Override
+        public float getV() {
+            return f2;
+        }
+
+        @Override
+        public void setV(float value) {
+            this.f2 = value;
         }
 
     }

--- a/core/src/main/java/hivemall/model/WeightValueWithClock.java
+++ b/core/src/main/java/hivemall/model/WeightValueWithClock.java
@@ -79,13 +79,48 @@ public class WeightValueWithClock implements IWeightValue {
     }
 
     @Override
+    public void setSumOfSquaredGradients(float value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public float getSumOfSquaredDeltaX() {
         return 0.f;
     }
 
     @Override
+    public void setSumOfSquaredDeltaX(float value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public float getSumOfGradients() {
         return 0.f;
+    }
+
+    @Override
+    public void setSumOfGradients(float value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float getM() {
+        return 0.f;
+    }
+
+    @Override
+    public void setM(float value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public float getV() {
+        return 0.f;
+    }
+
+    @Override
+    public void setV(float value) {
+        throw new UnsupportedOperationException();
     }
 
     /**
@@ -144,7 +179,7 @@ public class WeightValueWithClock implements IWeightValue {
      * WeightValue with Sum of Squared Gradients
      */
     public static final class WeightValueParamsF1Clock extends WeightValueWithClock {
-        private final float f1;
+        private float f1;
 
         public WeightValueParamsF1Clock(float value, float f1) {
             super(value);
@@ -174,11 +209,16 @@ public class WeightValueWithClock implements IWeightValue {
             return f1;
         }
 
+        @Override
+        public void setSumOfSquaredGradients(float value) {
+            this.f1 = value;
+        }
+
     }
 
     public static final class WeightValueParamsF2Clock extends WeightValueWithClock {
-        private final float f1;
-        private final float f2;
+        private float f1;
+        private float f2;
 
         public WeightValueParamsF2Clock(float value, float f1, float f2) {
             super(value);
@@ -213,13 +253,134 @@ public class WeightValueWithClock implements IWeightValue {
         }
 
         @Override
+        public void setSumOfSquaredGradients(float value) {
+            this.f1 = value;
+        }
+
+        @Override
         public float getSumOfSquaredDeltaX() {
             return f2;
         }
 
         @Override
+        public void setSumOfSquaredDeltaX(float value) {
+            this.f2 = value;
+        }
+
+        @Override
         public float getSumOfGradients() {
             return f2;
+        }
+
+        @Override
+        public void setSumOfGradients(float value) {
+            this.f2 = value;
+        }
+        @Override
+        public float getM() {
+            return f1;
+        }
+
+        @Override
+        public void setM(float value) {
+            this.f1 = value;
+        }
+
+        @Override
+        public float getV() {
+            return f2;
+        }
+
+        @Override
+        public void setV(float value) {
+            this.f2 = value;
+        }
+
+    }
+
+    public static final class WeightValueParamsF3Clock extends WeightValueWithClock {
+        private float f1;
+        private float f2;
+        private float f3;
+
+        public WeightValueParamsF3Clock(float value, float f1, float f2, float f3) {
+            super(value);
+            this.f1 = f1;
+            this.f2 = f2;
+            this.f3 = f3;
+        }
+
+        public WeightValueParamsF3Clock(IWeightValue src) {
+            super(src);
+            this.f1 = src.getFloatParams(1);
+            this.f2 = src.getFloatParams(2);
+            this.f3 = src.getFloatParams(3);
+        }
+
+        @Override
+        public WeightValueType getType() {
+            return WeightValueType.ParamsF3;
+        }
+
+        @Override
+        public float getFloatParams(@Nonnegative final int i) {
+            if(i == 1) {
+                return f1;
+            } else if(i == 2) {
+                return f2;
+            } else if(i == 3) {
+                return f3;
+            }
+            throw new IllegalArgumentException("getFloatParams(" + i + ") should not be called");
+        }
+
+        @Override
+        public float getSumOfSquaredGradients() {
+            return f1;
+        }
+
+        @Override
+        public void setSumOfSquaredGradients(float value) {
+            this.f1 = value;
+        }
+
+        @Override
+        public float getSumOfSquaredDeltaX() {
+            return f2;
+        }
+
+        @Override
+        public void setSumOfSquaredDeltaX(float value) {
+            this.f2 = value;
+        }
+
+        @Override
+        public float getSumOfGradients() {
+            return f3;
+        }
+
+        @Override
+        public void setSumOfGradients(float value) {
+            this.f3 = value;
+        }
+        @Override
+        public float getM() {
+            return f1;
+        }
+
+        @Override
+        public void setM(float value) {
+            this.f1 = value;
+        }
+
+        @Override
+        public float getV() {
+            return f2;
+        }
+
+        @Override
+        public void setV(float value) {
+            this.f2 = value;
         }
 
     }

--- a/core/src/main/java/hivemall/optimizer/DenseOptimizerFactory.java
+++ b/core/src/main/java/hivemall/optimizer/DenseOptimizerFactory.java
@@ -1,0 +1,215 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.optimizer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.Arrays;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import hivemall.optimizer.Optimizer.OptimizerBase;
+import hivemall.model.IWeightValue;
+import hivemall.model.WeightValue;
+import hivemall.utils.hadoop.HiveUtils;
+import hivemall.utils.math.MathUtils;
+
+public final class DenseOptimizerFactory {
+    private static final Log logger = LogFactory.getLog(DenseOptimizerFactory.class);
+
+    @Nonnull
+    public static Optimizer create(int ndims, @Nonnull Map<String, String> options) {
+        final String optimizerName = options.get("optimizer");
+        if(optimizerName != null) {
+            OptimizerBase optimizerImpl;
+            if(optimizerName.toLowerCase().equals("sgd")) {
+                optimizerImpl = new Optimizer.SGD(options);
+            } else if(optimizerName.toLowerCase().equals("adadelta")) {
+                optimizerImpl = new AdaDelta(ndims, options);
+            } else if(optimizerName.toLowerCase().equals("adagrad")) {
+                optimizerImpl = new AdaGrad(ndims, options);
+            } else if(optimizerName.toLowerCase().equals("adam")) {
+                optimizerImpl = new Adam(ndims, options);
+            } else {
+                throw new IllegalArgumentException("Unsupported optimizer name: " + optimizerName);
+            }
+
+            logger.info("set " + optimizerImpl.getClass().getSimpleName()
+                    + " as an optimizer: " + options);
+
+            // If a regularization type is "RDA", wrap the optimizer with `Optimizer#RDA`.
+            if(options.get("regularization") != null
+                    && options.get("regularization").toLowerCase().equals("rda")) {
+                optimizerImpl = new RDA(ndims, optimizerImpl, options);
+            }
+
+            return optimizerImpl;
+        }
+        throw new IllegalArgumentException("`optimizer` not defined");
+    }
+
+    @NotThreadSafe
+    static final class AdaDelta extends Optimizer.AdaDelta {
+
+        private final IWeightValue weightValueReused;
+
+        private float[] sum_of_squared_gradients;
+        private float[] sum_of_squared_delta_x;
+
+        public AdaDelta(int ndims, Map<String, String> options) {
+            super(options);
+            this.weightValueReused = new WeightValue.WeightValueParamsF2(0.f, 0.f, 0.f);
+            this.sum_of_squared_gradients = new float[ndims];
+            this.sum_of_squared_delta_x = new float[ndims];
+        }
+
+        @Override
+        public float computeUpdatedValue(@Nonnull Object feature, float weight, float gradient) {
+            int i = HiveUtils.parseInt(feature);
+            ensureCapacity(i);
+            weightValueReused.set(weight);
+            weightValueReused.setSumOfSquaredGradients(sum_of_squared_gradients[i]);
+            weightValueReused.setSumOfSquaredDeltaX(sum_of_squared_delta_x[i]);
+            computeUpdateValue(weightValueReused, gradient);
+            sum_of_squared_gradients[i] = weightValueReused.getSumOfSquaredGradients();
+            sum_of_squared_delta_x[i] = weightValueReused.getSumOfSquaredDeltaX();
+            return weightValueReused.get();
+        }
+
+        private void ensureCapacity(final int index) {
+            if(index >= sum_of_squared_gradients.length) {
+                int bits = MathUtils.bitsRequired(index);
+                int newSize = (1 << bits) + 1;
+                this.sum_of_squared_gradients = Arrays.copyOf(sum_of_squared_gradients, newSize);
+                this.sum_of_squared_delta_x = Arrays.copyOf(sum_of_squared_delta_x, newSize);
+            }
+        }
+
+    }
+
+    @NotThreadSafe
+    static final class AdaGrad extends Optimizer.AdaGrad {
+
+        private final IWeightValue weightValueReused;
+
+        private float[] sum_of_squared_gradients;
+
+        public AdaGrad(int ndims, Map<String, String> options) {
+            super(options);
+            this.weightValueReused = new WeightValue.WeightValueParamsF1(0.f, 0.f);
+            this.sum_of_squared_gradients = new float[ndims];
+        }
+
+        @Override
+        public float computeUpdatedValue(@Nonnull Object feature, float weight, float gradient) {
+            int i = HiveUtils.parseInt(feature);
+            ensureCapacity(i);
+            weightValueReused.set(weight);
+            weightValueReused.setSumOfSquaredGradients(sum_of_squared_gradients[i]);
+            computeUpdateValue(weightValueReused, gradient);
+            sum_of_squared_gradients[i] = weightValueReused.getSumOfSquaredGradients();
+            return weightValueReused.get();
+        }
+
+        private void ensureCapacity(final int index) {
+            if(index >= sum_of_squared_gradients.length) {
+                int bits = MathUtils.bitsRequired(index);
+                int newSize = (1 << bits) + 1;
+                this.sum_of_squared_gradients = Arrays.copyOf(sum_of_squared_gradients, newSize);
+            }
+        }
+
+    }
+
+    @NotThreadSafe
+    static final class Adam extends Optimizer.Adam {
+
+        private final IWeightValue weightValueReused;
+
+        private float[] val_m;
+        private float[] val_v;
+
+        public Adam(int ndims, Map<String, String> options) {
+            super(options);
+            this.weightValueReused = new WeightValue.WeightValueParamsF2(0.f, 0.f, 0.f);
+            this.val_m = new float[ndims];
+            this.val_v = new float[ndims];
+        }
+
+        @Override
+        public float computeUpdatedValue(@Nonnull Object feature, float weight, float gradient) {
+            int i = HiveUtils.parseInt(feature);
+            ensureCapacity(i);
+            weightValueReused.set(weight);
+            weightValueReused.setM(val_m[i]);
+            weightValueReused.setV(val_v[i]);
+            computeUpdateValue(weightValueReused, gradient);
+            val_m[i] = weightValueReused.getM();
+            val_v[i] = weightValueReused.getV();
+            return weightValueReused.get();
+        }
+
+        private void ensureCapacity(final int index) {
+            if(index >= val_m.length) {
+                int bits = MathUtils.bitsRequired(index);
+                int newSize = (1 << bits) + 1;
+                this.val_m = Arrays.copyOf(val_m, newSize);
+                this.val_v = Arrays.copyOf(val_v, newSize);
+            }
+        }
+
+    }
+
+    @NotThreadSafe
+    static final class RDA extends Optimizer.RDA {
+
+        private final IWeightValue weightValueReused;
+
+        private float[] sum_of_gradients;
+
+        public RDA(int ndims, final OptimizerBase optimizerImpl, Map<String, String> options) {
+            super(optimizerImpl, options);
+            this.weightValueReused = new WeightValue.WeightValueParamsF3(0.f, 0.f, 0.f, 0.f);
+            this.sum_of_gradients = new float[ndims];
+        }
+
+        @Override
+        public float computeUpdatedValue(@Nonnull Object feature, float weight, float gradient) {
+            int i = HiveUtils.parseInt(feature);
+            ensureCapacity(i);
+            weightValueReused.set(weight);
+            weightValueReused.setSumOfGradients(sum_of_gradients[i]);
+            computeUpdateValue(weightValueReused, gradient);
+            sum_of_gradients[i] = weightValueReused.getSumOfGradients();
+            return weightValueReused.get();
+        }
+
+        private void ensureCapacity(final int index) {
+            if(index >= sum_of_gradients.length) {
+                int bits = MathUtils.bitsRequired(index);
+                int newSize = (1 << bits) + 1;
+                this.sum_of_gradients = Arrays.copyOf(sum_of_gradients, newSize);
+            }
+        }
+
+    }
+
+}

--- a/core/src/main/java/hivemall/optimizer/DenseOptimizerFactory.java
+++ b/core/src/main/java/hivemall/optimizer/DenseOptimizerFactory.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.optimizer;
 

--- a/core/src/main/java/hivemall/optimizer/EtaEstimator.java
+++ b/core/src/main/java/hivemall/optimizer/EtaEstimator.java
@@ -16,11 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package hivemall.common;
+package hivemall.optimizer;
 
 import hivemall.utils.lang.NumberUtils;
 import hivemall.utils.lang.Primitives;
 
+import java.util.Map;
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -155,6 +156,36 @@ public abstract class EtaEstimator {
 
         double power_t = Primitives.parseDouble(cl.getOptionValue("power_t"), 0.1d);
         return new InvscalingEtaEstimator(eta0, power_t);
+    }
+
+    @Nonnull
+    public static EtaEstimator get(@Nonnull final Map<String, String> options)
+            throws IllegalArgumentException {
+        final String etaName = options.get("eta");
+        if(etaName == null) {
+            return new FixedEtaEstimator(1.f);
+        }
+        float eta0 = 0.1f;
+        if(options.containsKey("eta0")) {
+            eta0 = Float.parseFloat(options.get("eta0"));
+        }
+        if(etaName.toLowerCase().equals("fixed")) {
+            return new FixedEtaEstimator(eta0);
+        } else if(etaName.toLowerCase().equals("simple")) {
+            long t = 10000;
+            if(options.containsKey("t")) {
+                t = Long.parseLong(options.get("t"));
+            }
+            return new SimpleEtaEstimator(eta0, t);
+        } else if(etaName.toLowerCase().equals("inverse")) {
+            double power_t = 0.1;
+            if(options.containsKey("power_t")) {
+                power_t = Double.parseDouble(options.get("power_t"));
+            }
+            return new InvscalingEtaEstimator(eta0, power_t);
+        } else {
+            throw new IllegalArgumentException("Unsupported ETA name: " + etaName);
+        }
     }
 
 }

--- a/core/src/main/java/hivemall/optimizer/LossFunctions.java
+++ b/core/src/main/java/hivemall/optimizer/LossFunctions.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package hivemall.common;
+package hivemall.optimizer;
 
 import hivemall.utils.math.MathUtils;
 
@@ -69,7 +69,7 @@ public final class LossFunctions {
 
         /**
          * Evaluate the loss function.
-         * 
+         *
          * @param p The prediction, p = w^T x
          * @param y The true value (aka target)
          * @return The loss evaluated at `p` and `y`.
@@ -80,7 +80,7 @@ public final class LossFunctions {
 
         /**
          * Evaluate the derivative of the loss function with respect to the prediction `p`.
-         * 
+         *
          * @param p The prediction, p = w^T x
          * @param y The true value (aka target)
          * @return The derivative of the loss function w.r.t. `p`.
@@ -134,7 +134,7 @@ public final class LossFunctions {
 
     /**
      * Squared loss for regression problems.
-     * 
+     *
      * If you're trying to minimize the mean error, use squared-loss.
      */
     public static final class SquaredLoss extends RegressionLoss {
@@ -278,7 +278,7 @@ public final class LossFunctions {
     /**
      * Quantile loss is useful to predict rank/order and you do not mind the mean error to increase
      * as long as you get the relative order correct.
-     * 
+     *
      * @link http://en.wikipedia.org/wiki/Quantile_regression
      */
     public static final class QuantileLoss extends RegressionLoss {

--- a/core/src/main/java/hivemall/optimizer/LossFunctions.java
+++ b/core/src/main/java/hivemall/optimizer/LossFunctions.java
@@ -100,6 +100,8 @@ public final class LossFunctions {
 
         public boolean forRegression();
 
+        public LossType getType();
+
     }
 
     public static abstract class RegressionLoss implements LossFunction {
@@ -165,8 +167,8 @@ public final class LossFunctions {
         }
 
         @Override
-        public String toString() {
-            return "SquaredLoss";
+        public LossType getType() {
+            return LossType.SquaredLoss;
         }
     }
 
@@ -225,8 +227,8 @@ public final class LossFunctions {
         }
 
         @Override
-        public String toString() {
-            return "QuantileLoss";
+        public LossType getType() {
+            return LossType.QuantileLoss;
         }
     }
 
@@ -274,8 +276,8 @@ public final class LossFunctions {
         }
 
         @Override
-        public String toString() {
-            return "EpsilonInsensitiveLoss";
+        public LossType getType() {
+            return LossType.EpsilonInsensitiveLoss;
         }
     }
 
@@ -335,8 +337,8 @@ public final class LossFunctions {
         }
 
         @Override
-        public String toString() {
-            return "HuberLoss";
+        public LossType getType() {
+            return LossType.HuberLoss;
         }
     }
 
@@ -382,8 +384,8 @@ public final class LossFunctions {
         }
 
         @Override
-        public String toString() {
-            return "HingeLoss";
+        public LossType getType() {
+            return LossType.HingeLoss;
         }
     }
 
@@ -438,8 +440,8 @@ public final class LossFunctions {
         }
 
         @Override
-        public String toString() {
-            return "LogisticRegressionLoss";
+        public LossType getType() {
+            return LossType.LogLoss;
         }
     }
 
@@ -467,8 +469,8 @@ public final class LossFunctions {
         }
 
         @Override
-        public String toString() {
-            return "SquaredHingeLoss";
+        public LossType getType() {
+            return LossType.SquaredHingeLoss;
         }
     }
 
@@ -513,8 +515,8 @@ public final class LossFunctions {
         }
 
         @Override
-        public String toString() {
-            return "ModifiedHuberLoss";
+        public LossType getType() {
+            return LossType.ModifiedHuberLoss;
         }
     }
 

--- a/core/src/main/java/hivemall/optimizer/LossFunctions.java
+++ b/core/src/main/java/hivemall/optimizer/LossFunctions.java
@@ -43,7 +43,7 @@ public final class LossFunctions {
         } else if ("EpsilonInsensitiveLoss".equalsIgnoreCase(type)) {
             return new EpsilonInsensitiveLoss();
         }
-        throw new IllegalArgumentException("Unsupported type: " + type);
+        throw new IllegalArgumentException("Unsupported loss function name: " + type);
     }
 
     public static LossFunction getLossFunction(LossType type) {
@@ -61,7 +61,7 @@ public final class LossFunctions {
             case EpsilonInsensitiveLoss:
                 return new EpsilonInsensitiveLoss();
             default:
-                throw new IllegalArgumentException("Unsupported type: " + type);
+                throw new IllegalArgumentException("Unsupported loss function name: " + type);
         }
     }
 
@@ -129,7 +129,6 @@ public final class LossFunctions {
         public boolean forRegression() {
             return true;
         }
-
     }
 
     /**
@@ -154,6 +153,11 @@ public final class LossFunctions {
         @Override
         public float dloss(float p, float y) {
             return p - y; // 2 (p - y) / 2
+        }
+
+        @Override
+        public String toString() {
+            return "SquaredLoss";
         }
     }
 
@@ -206,6 +210,11 @@ public final class LossFunctions {
             }
             return -y / ((float) Math.exp(z) + 1.f);
         }
+
+        @Override
+        public String toString() {
+            return "LogisticRegressionLoss";
+        }
     }
 
     /**
@@ -248,6 +257,11 @@ public final class LossFunctions {
             float loss = hingeLoss(p, y, threshold);
             return (loss > 0.f) ? -y : 0.f;
         }
+
+        @Override
+        public String toString() {
+            return "HingeLoss";
+        }
     }
 
     /**
@@ -273,6 +287,10 @@ public final class LossFunctions {
             return (d > 0.f) ? -2.f * d * y : 0.f;
         }
 
+        @Override
+        public String toString() {
+            return "SquaredHingeLoss";
+        }
     }
 
     /**
@@ -329,6 +347,10 @@ public final class LossFunctions {
             return (e > 0.f) ? -tau : (1.f - tau);
         }
 
+        @Override
+        public String toString() {
+            return "QuantileLoss";
+        }
     }
 
     /**
@@ -374,6 +396,10 @@ public final class LossFunctions {
             return 0.f;
         }
 
+        @Override
+        public String toString() {
+            return "EpsilonInsensitiveLoss";
+        }
     }
 
     public static float logisticLoss(final float target, final float predicted) {

--- a/core/src/main/java/hivemall/optimizer/LossFunctions.java
+++ b/core/src/main/java/hivemall/optimizer/LossFunctions.java
@@ -26,8 +26,8 @@ import hivemall.utils.math.MathUtils;
 public final class LossFunctions {
 
     public enum LossType {
-        SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss,
-        HingeLoss, LogLoss, SquaredHingeLoss, ModifiedHuberLoss
+        SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss, HingeLoss, LogLoss,
+        SquaredHingeLoss, ModifiedHuberLoss
     }
 
     public static LossFunction getLossFunction(String type) {
@@ -173,8 +173,7 @@ public final class LossFunctions {
     }
 
     /**
-     * Quantile loss is useful to predict rank/order and you do not mind the mean error to increase
-     * as long as you get the relative order correct.
+     * Quantile loss is useful to predict rank/order and you do not mind the mean error to increase as long as you get the relative order correct.
      *
      * @link http://en.wikipedia.org/wiki/Quantile_regression
      */
@@ -233,8 +232,7 @@ public final class LossFunctions {
     }
 
     /**
-     * Epsilon-Insensitive loss used by Support Vector Regression (SVR).
-     * <code>loss = max(0, |y - p| - epsilon)</code>
+     * Epsilon-Insensitive loss used by Support Vector Regression (SVR). <code>loss = max(0, |y - p| - epsilon)</code>
      */
     public static final class EpsilonInsensitiveLoss extends RegressionLoss {
 
@@ -354,8 +352,8 @@ public final class LossFunctions {
         }
 
         /**
-         * @param threshold Margin threshold. When threshold=1.0, one gets the loss used by SVM.
-         *        When threshold=0.0, one gets the loss used by the Perceptron.
+         * @param threshold Margin threshold. When threshold=1.0, one gets the loss used by SVM. When threshold=0.0, one gets the loss used by the
+         *        Perceptron.
          */
         public HingeLoss(float threshold) {
             this.threshold = threshold;

--- a/core/src/main/java/hivemall/optimizer/Optimizer.java
+++ b/core/src/main/java/hivemall/optimizer/Optimizer.java
@@ -1,0 +1,246 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.optimizer;
+
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+
+import hivemall.model.WeightValue;
+import hivemall.model.IWeightValue;
+
+public interface Optimizer {
+
+    /**
+     * Update the weights of models thru this interface.
+     */
+    float computeUpdatedValue(@Nonnull Object feature, float weight, float gradient);
+
+    // Count up #step to tune learning rate
+    void proceedStep();
+
+    static abstract class OptimizerBase implements Optimizer {
+
+        protected final EtaEstimator etaImpl;
+        protected final Regularization regImpl;
+
+        protected int numStep = 1;
+
+        public OptimizerBase(final Map<String, String> options) {
+            this.etaImpl = EtaEstimator.get(options);
+            this.regImpl = Regularization.get(options);
+        }
+
+        @Override
+        public void proceedStep() {
+            numStep++;
+        }
+
+        // Directly update a given `weight` in terms of performance
+        protected void computeUpdateValue(
+                @Nonnull final IWeightValue weight, float gradient) {
+            float delta = computeUpdateValueImpl(weight, regImpl.regularize(weight.get(), gradient));
+            weight.set(weight.get() - etaImpl.eta(numStep) * delta);
+        }
+
+        // Compute a delta to update
+        protected float computeUpdateValueImpl(
+                @Nonnull final IWeightValue weight, float gradient) {
+            return gradient;
+        }
+
+    }
+
+    @NotThreadSafe
+    static final class SGD extends OptimizerBase {
+
+        private final IWeightValue weightValueReused;
+
+        public SGD(final Map<String, String> options) {
+            super(options);
+            this.weightValueReused = new WeightValue(0.f);
+        }
+
+        @Override
+        public float computeUpdatedValue(
+                @Nonnull Object feature, float weight, float gradient) {
+            computeUpdateValue(weightValueReused, gradient);
+            return weightValueReused.get();
+        }
+
+    }
+
+    static abstract class AdaDelta extends OptimizerBase {
+
+        private final float decay;
+        private final float eps;
+        private final float scale;
+
+        public AdaDelta(Map<String, String> options) {
+            super(options);
+            float decay = 0.95f;
+            float eps = 1e-6f;
+            float scale = 100.0f;
+            if(options.containsKey("decay")) {
+                decay = Float.parseFloat(options.get("decay"));
+            }
+            if(options.containsKey("eps")) {
+                eps = Float.parseFloat(options.get("eps"));
+            }
+            if(options.containsKey("scale")) {
+                scale = Float.parseFloat(options.get("scale"));
+            }
+            this.decay = decay;
+            this.eps = eps;
+            this.scale = scale;
+        }
+
+        @Override
+        protected float computeUpdateValueImpl(@Nonnull final IWeightValue weight, float gradient)  {
+            float old_scaled_sum_sqgrad = weight.getSumOfSquaredGradients();
+            float old_sum_squared_delta_x = weight.getSumOfSquaredDeltaX();
+            float new_scaled_sum_sqgrad = (decay * old_scaled_sum_sqgrad) + ((1.f - decay) * gradient * (gradient / scale));
+            float delta = (float) Math.sqrt((old_sum_squared_delta_x + eps) / (new_scaled_sum_sqgrad * scale + eps)) * gradient;
+            float new_sum_squared_delta_x = (decay * old_sum_squared_delta_x) + ((1.f - decay) * delta * delta);
+            weight.setSumOfSquaredGradients(new_scaled_sum_sqgrad);
+            weight.setSumOfSquaredDeltaX(new_sum_squared_delta_x);
+            return delta;
+        }
+
+    }
+
+    static abstract class AdaGrad extends OptimizerBase {
+
+        private final float eps;
+        private final float scale;
+
+        public AdaGrad(Map<String, String> options) {
+            super(options);
+            float eps = 1.0f;
+            float scale = 100.0f;
+            if(options.containsKey("eps")) {
+                eps = Float.parseFloat(options.get("eps"));
+            }
+            if(options.containsKey("scale")) {
+                scale = Float.parseFloat(options.get("scale"));
+            }
+            this.eps = eps;
+            this.scale = scale;
+        }
+
+        @Override
+        protected float computeUpdateValueImpl(@Nonnull final IWeightValue weight, float gradient) {
+            float new_scaled_sum_sqgrad = weight.getSumOfSquaredGradients() + gradient * (gradient / scale);
+            float delta = gradient / ((float) Math.sqrt(new_scaled_sum_sqgrad * scale) + eps);
+            weight.setSumOfSquaredGradients(new_scaled_sum_sqgrad);
+            return delta;
+        }
+
+    }
+
+    /**
+     * Adam, an algorithm for first-order gradient-based optimization of stochastic objective
+     * functions, based on adaptive estimates of lower-order moments.
+     *
+     *  - D. P. Kingma and J. L. Ba: "ADAM: A Method for Stochastic Optimization." arXiv preprint arXiv:1412.6980v8, 2014.
+     */
+    static abstract class Adam extends OptimizerBase {
+
+        private final float beta;
+        private final float gamma;
+        private final float eps_hat;
+
+        public Adam(Map<String, String> options) {
+            super(options);
+            float beta = 0.9f;
+            float gamma = 0.999f;
+            float eps_hat = 1e-8f;
+            if(options.containsKey("beta")) {
+                beta = Float.parseFloat(options.get("beta"));
+            }
+            if(options.containsKey("gamma")) {
+                gamma = Float.parseFloat(options.get("gamma"));
+            }
+            if(options.containsKey("eps_hat")) {
+                eps_hat = Float.parseFloat(options.get("eps_hat"));
+            }
+            this.beta = beta;
+            this.gamma = gamma;
+            this.eps_hat = eps_hat;
+        }
+
+        @Override
+        protected float computeUpdateValueImpl(@Nonnull final IWeightValue weight, float gradient) {
+            float val_m = beta * weight.getM() + (1.f - beta) * gradient;
+            float val_v = gamma * weight.getV() + (float) ((1.f - gamma) * Math.pow(gradient, 2.0));
+            float val_m_hat = val_m / (float) (1.f - Math.pow(beta, numStep));
+            float val_v_hat = val_v / (float) (1.f - Math.pow(gamma, numStep));
+            float delta = val_m_hat / (float) (Math.sqrt(val_v_hat) + eps_hat);
+            weight.setM(val_m);
+            weight.setV(val_v);
+            return delta;
+        }
+
+    }
+
+    static abstract class RDA extends OptimizerBase {
+
+        private final OptimizerBase optimizerImpl;
+
+        private final float lambda;
+
+        public RDA(final OptimizerBase optimizerImpl, Map<String, String> options) {
+            super(options);
+            // We assume `optimizerImpl` has the `AdaGrad` implementation only
+            if(!(optimizerImpl instanceof AdaGrad)) {
+                throw new IllegalArgumentException(
+                        optimizerImpl.getClass().getSimpleName()
+                        + " currently does not support RDA regularization");
+            }
+            float lambda = 1e-6f;
+            if(options.containsKey("lambda")) {
+                lambda = Float.parseFloat(options.get("lambda"));
+            }
+            this.optimizerImpl = optimizerImpl;
+            this.lambda = lambda;
+        }
+
+        @Override
+        protected void computeUpdateValue(@Nonnull final IWeightValue weight, float gradient) {
+            float new_sum_grad = weight.getSumOfGradients() + gradient;
+            // sign(u_{t,i})
+            float sign = (new_sum_grad > 0.f)? 1.f : -1.f;
+            // |u_{t,i}|/t - \lambda
+            float meansOfGradients = (sign * new_sum_grad / numStep) - lambda;
+            if(meansOfGradients < 0.f) {
+                // x_{t,i} = 0
+                weight.set(0.f);
+                weight.setSumOfSquaredGradients(0.f);
+                weight.setSumOfGradients(0.f);
+            } else {
+                // x_{t,i} = -sign(u_{t,i}) * \frac{\eta t}{\sqrt{G_{t,ii}}}(|u_{t,i}|/t - \lambda)
+                float new_weight = -1.f * sign * etaImpl.eta(numStep) * numStep * optimizerImpl.computeUpdateValueImpl(weight, meansOfGradients);
+                weight.set(new_weight);
+                weight.setSumOfGradients(new_sum_grad);
+            }
+        }
+
+    }
+
+}

--- a/core/src/main/java/hivemall/optimizer/Optimizer.java
+++ b/core/src/main/java/hivemall/optimizer/Optimizer.java
@@ -90,6 +90,7 @@ public interface Optimizer {
 
         @Override
         public float update(@Nonnull Object feature, float weight, float gradient) {
+            weightValueReused.set(weight);
             update(weightValueReused, gradient);
             return weightValueReused.get();
         }

--- a/core/src/main/java/hivemall/optimizer/Optimizer.java
+++ b/core/src/main/java/hivemall/optimizer/Optimizer.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.optimizer;
 

--- a/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
+++ b/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
@@ -43,10 +43,11 @@ public final class OptimizerOptions {
     public static void setup(@Nonnull Options opts) {
         opts.addOption("opt", "optimizer", true,
             "Optimizer to update weights [default: adagrad, sgd, adadelta, adam]");
-        opts.addOption("eps",  true, "Denominator value of AdaDelta/AdaGrad [default 1e-6]");
+        opts.addOption("eps", true, "Denominator value of AdaDelta/AdaGrad [default 1e-6]");
         opts.addOption("rho", "decay", true, "Decay rate of AdaDelta [default 0.95]");
         // regularization
-        opts.addOption("reg", "regularization", true, "Regularization type [default: rda, l1, l2, elasticnet]");
+        opts.addOption("reg", "regularization", true,
+            "Regularization type [default: rda, l1, l2, elasticnet]");
         opts.addOption("lambda", true, "Regularization term [default 0.0001]");
         // learning rates
         opts.addOption("eta", true, "Learning rate scheme [default: inverse/inv, fixed, simple]");

--- a/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
+++ b/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
+import org.apache.commons.cli.Option;
 
 public final class OptimizerOptions {
 
@@ -40,12 +41,12 @@ public final class OptimizerOptions {
     }
 
     public static void setup(@Nonnull Options opts) {
-        opts.addOption("optimizer", "opt", true,
+        opts.addOption("opt", "optimizer", true,
             "Optimizer to update weights [default: adagrad, sgd, adadelta, adam]");
-        opts.addOption("eps", true, "Denominator value of AdaDelta/AdaGrad [default 1e-6]");
+        opts.addOption("eps",  true, "Denominator value of AdaDelta/AdaGrad [default 1e-6]");
         opts.addOption("rho", "decay", true, "Decay rate of AdaDelta [default 0.95]");
         // regularization
-        opts.addOption("regularization", "reg", true, "Regularization type [default: rda, l1, l2]");
+        opts.addOption("reg", "regularization", true, "Regularization type [default: rda, l1, l2]");
         opts.addOption("lambda", true, "Regularization term [default 0.0001]");
         // learning rates
         opts.addOption("eta", true, "Learning rate scheme [default: inverse/inv, fixed, simple]");
@@ -60,8 +61,12 @@ public final class OptimizerOptions {
     public static void propcessOptions(@Nullable CommandLine cl,
             @Nonnull Map<String, String> options) {
         if (cl != null) {
-            for (String arg : cl.getArgs()) {
-                options.put(arg, cl.getOptionValue(arg));
+            for (Option opt : cl.getOptions()) {
+                String optName = opt.getLongOpt();
+                if (optName == null) {
+                    optName = opt.getOpt();
+                }
+                options.put(optName, opt.getValue());
             }
         }
     }

--- a/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
+++ b/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
@@ -46,7 +46,7 @@ public final class OptimizerOptions {
         opts.addOption("eps",  true, "Denominator value of AdaDelta/AdaGrad [default 1e-6]");
         opts.addOption("rho", "decay", true, "Decay rate of AdaDelta [default 0.95]");
         // regularization
-        opts.addOption("reg", "regularization", true, "Regularization type [default: rda, l1, l2]");
+        opts.addOption("reg", "regularization", true, "Regularization type [default: rda, l1, l2, elasticnet]");
         opts.addOption("lambda", true, "Regularization term [default 0.0001]");
         // learning rates
         opts.addOption("eta", true, "Learning rate scheme [default: inverse/inv, fixed, simple]");

--- a/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
+++ b/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
@@ -48,6 +48,8 @@ public final class OptimizerOptions {
         // regularization
         opts.addOption("reg", "regularization", true,
             "Regularization type [default: rda, l1, l2, elasticnet]");
+        opts.addOption("l1_ratio", true,
+            "Ratio of L1 regularizer as a part of Elastic Net regularization [default: 0.5]");
         opts.addOption("lambda", true, "Regularization term [default 0.0001]");
         // learning rates
         opts.addOption("eta", true, "Learning rate scheme [default: inverse/inv, fixed, simple]");

--- a/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
+++ b/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.optimizer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+
+public final class OptimizerOptions {
+
+    private OptimizerOptions() {}
+
+    @Nonnull
+    public static Map<String, String> create() {
+        Map<String, String> opts = new HashMap<String, String>();
+        opts.put("optimizer", "adagrad");
+        opts.put("regularization", "RDA");
+        return opts;
+    }
+
+    public static void setup(@Nonnull Options opts) {
+        opts.addOption("optimizer", "opt", true,
+            "Optimizer to update weights [default: adagrad, sgd, adadelta, adam]");
+        opts.addOption("eps", true, "Denominator value of AdaDelta/AdaGrad [default 1e-6]");
+        opts.addOption("rho", "decay", true, "Decay rate of AdaDelta [default 0.95]");
+        // regularization
+        opts.addOption("regularization", "reg", true, "Regularization type [default: rda, l1, l2]");
+        opts.addOption("lambda", true, "Regularization term [default 0.0001]");
+        // learning rates
+        opts.addOption("eta", true, "Learning rate scheme [default: inverse/inv, fixed, simple]");
+        opts.addOption("eta0", true, "The initial learning rate [default 0.1]");
+        opts.addOption("t", "total_steps", true, "a total of n_samples * epochs time steps");
+        opts.addOption("power_t", true,
+            "The exponent for inverse scaling learning rate [default 0.1]");
+        // other
+        opts.addOption("scale", true, "Scaling factor for cumulative weights [100.0]");
+    }
+
+    public static void propcessOptions(@Nullable CommandLine cl,
+            @Nonnull Map<String, String> options) {
+        if (cl != null) {
+            for (String arg : cl.getArgs()) {
+                options.put(arg, cl.getOptionValue(arg));
+            }
+        }
+    }
+
+}

--- a/core/src/main/java/hivemall/optimizer/Regularization.java
+++ b/core/src/main/java/hivemall/optimizer/Regularization.java
@@ -22,11 +22,13 @@ import javax.annotation.Nonnull;
 import java.util.Map;
 
 public abstract class Regularization {
+    /** the default regularization term 0.0001 */
+    public static final float DEFAULT_LAMBDA = 0.0001f;
 
     protected final float lambda;
 
-    public Regularization(final Map<String, String> options) {
-        float lambda = 1e-6f;
+    public Regularization(@Nonnull Map<String, String> options) {
+        float lambda = DEFAULT_LAMBDA;
         if(options.containsKey("lambda")) {
             lambda = Float.parseFloat(options.get("lambda"));
         }
@@ -81,6 +83,7 @@ public abstract class Regularization {
         if (regName == null) {
             return new PassThrough(options);
         }
+        
         if(regName.toLowerCase().equals("no")) {
             return new PassThrough(options);
         } else if(regName.toLowerCase().equals("l1")) {

--- a/core/src/main/java/hivemall/optimizer/Regularization.java
+++ b/core/src/main/java/hivemall/optimizer/Regularization.java
@@ -58,7 +58,7 @@ public abstract class Regularization {
 
         @Override
         public float regularize(float weight, float gradient) {
-            return gradient + lambda * (weight > 0.f? 1.f : -1.f);
+            return gradient + lambda * (weight > 0.f ? 1.f : -1.f);
         }
 
     }
@@ -76,6 +76,17 @@ public abstract class Regularization {
 
     }
 
+    public static final class ElasticNet extends Regularization {
+        public ElasticNet(Map<String, String> options) {
+            super(options);
+        }
+
+        @Override
+        public float regularize(float weight, float gradient) {
+            return gradient + lambda * (weight > 0.f ? 1.f : -1.f) + lambda * weight;
+        }
+    }
+
     @Nonnull
     public static Regularization get(@Nonnull final Map<String, String> options)
             throws IllegalArgumentException {
@@ -84,13 +95,15 @@ public abstract class Regularization {
             return new PassThrough(options);
         }
         
-        if(regName.toLowerCase().equals("no")) {
+        if (regName.toLowerCase().equals("no")) {
             return new PassThrough(options);
-        } else if(regName.toLowerCase().equals("l1")) {
+        } else if (regName.toLowerCase().equals("l1")) {
             return new L1(options);
-        } else if(regName.toLowerCase().equals("l2")) {
+        } else if (regName.toLowerCase().equals("l2")) {
             return new L2(options);
-        } else if(regName.toLowerCase().equals("rda")) {
+        } else if (regName.toLowerCase().equals("elasticnet")) {
+            return new ElasticNet(options);
+        } else if (regName.toLowerCase().equals("rda")) {
             // Return `PassThrough` because we need special handling for RDA.
             // See an implementation of `Optimizer#RDA`.
             return new PassThrough(options);

--- a/core/src/main/java/hivemall/optimizer/Regularization.java
+++ b/core/src/main/java/hivemall/optimizer/Regularization.java
@@ -98,7 +98,8 @@ public abstract class Regularization {
             if (options.containsKey("l1_ratio")) {
                 l1Ratio = Float.parseFloat(options.get("l1_ratio"));
                 if (l1Ratio < 0.f || l1Ratio > 1.f) {
-                    throw new IllegalArgumentException("L1 ratio should be in [0.0, 1.0], but got " + l1Ratio);
+                    throw new IllegalArgumentException("L1 ratio should be in [0.0, 1.0], but got "
+                            + l1Ratio);
                 }
             }
             this.l1Ratio = l1Ratio;
@@ -106,7 +107,8 @@ public abstract class Regularization {
 
         @Override
         public float getRegularizer(float weight) {
-            return l1Ratio * l1.getRegularizer(weight) + (1.f - l1Ratio) * l2.getRegularizer(weight);
+            return l1Ratio * l1.getRegularizer(weight) + (1.f - l1Ratio)
+                    * l2.getRegularizer(weight);
         }
     }
 

--- a/core/src/main/java/hivemall/optimizer/Regularization.java
+++ b/core/src/main/java/hivemall/optimizer/Regularization.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.optimizer;
 

--- a/core/src/main/java/hivemall/optimizer/Regularization.java
+++ b/core/src/main/java/hivemall/optimizer/Regularization.java
@@ -29,7 +29,7 @@ public abstract class Regularization {
 
     public Regularization(@Nonnull Map<String, String> options) {
         float lambda = DEFAULT_LAMBDA;
-        if(options.containsKey("lambda")) {
+        if (options.containsKey("lambda")) {
             lambda = Float.parseFloat(options.get("lambda"));
         }
         this.lambda = lambda;
@@ -94,7 +94,7 @@ public abstract class Regularization {
         if (regName == null) {
             return new PassThrough(options);
         }
-        
+
         if (regName.toLowerCase().equals("no")) {
             return new PassThrough(options);
         } else if (regName.toLowerCase().equals("l1")) {

--- a/core/src/main/java/hivemall/optimizer/Regularization.java
+++ b/core/src/main/java/hivemall/optimizer/Regularization.java
@@ -1,0 +1,99 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.optimizer;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+
+public abstract class Regularization {
+
+    protected final float lambda;
+
+    public Regularization(final Map<String, String> options) {
+        float lambda = 1e-6f;
+        if(options.containsKey("lambda")) {
+            lambda = Float.parseFloat(options.get("lambda"));
+        }
+        this.lambda = lambda;
+    }
+
+    abstract float regularize(float weight, float gradient);
+
+    public static final class PassThrough extends Regularization {
+
+        public PassThrough(final Map<String, String> options) {
+            super(options);
+        }
+
+        @Override
+        public float regularize(float weight, float gradient) {
+            return gradient;
+        }
+
+    }
+
+    public static final class L1 extends Regularization {
+
+        public L1(Map<String, String> options) {
+            super(options);
+        }
+
+        @Override
+        public float regularize(float weight, float gradient) {
+            return gradient + lambda * (weight > 0.f? 1.f : -1.f);
+        }
+
+    }
+
+    public static final class L2 extends Regularization {
+
+        public L2(final Map<String, String> options) {
+            super(options);
+        }
+
+        @Override
+        public float regularize(float weight, float gradient) {
+            return gradient + lambda * weight;
+        }
+
+    }
+
+    @Nonnull
+    public static Regularization get(@Nonnull final Map<String, String> options)
+            throws IllegalArgumentException {
+        final String regName = options.get("regularization");
+        if (regName == null) {
+            return new PassThrough(options);
+        }
+        if(regName.toLowerCase().equals("no")) {
+            return new PassThrough(options);
+        } else if(regName.toLowerCase().equals("l1")) {
+            return new L1(options);
+        } else if(regName.toLowerCase().equals("l2")) {
+            return new L2(options);
+        } else if(regName.toLowerCase().equals("rda")) {
+            // Return `PassThrough` because we need special handling for RDA.
+            // See an implementation of `Optimizer#RDA`.
+            return new PassThrough(options);
+        } else {
+            throw new IllegalArgumentException("Unsupported regularization name: " + regName);
+        }
+    }
+
+}

--- a/core/src/main/java/hivemall/optimizer/SparseOptimizerFactory.java
+++ b/core/src/main/java/hivemall/optimizer/SparseOptimizerFactory.java
@@ -1,0 +1,171 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.optimizer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.NotThreadSafe;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import hivemall.optimizer.Optimizer.OptimizerBase;
+import hivemall.model.IWeightValue;
+import hivemall.model.WeightValue;
+import hivemall.utils.collections.OpenHashMap;
+
+public final class SparseOptimizerFactory {
+    private static final Log logger = LogFactory.getLog(SparseOptimizerFactory.class);
+
+    @Nonnull
+    public static Optimizer create(int ndims, @Nonnull Map<String, String> options) {
+        final String optimizerName = options.get("optimizer");
+        if(optimizerName != null) {
+            OptimizerBase optimizerImpl;
+            if(optimizerName.toLowerCase().equals("sgd")) {
+                optimizerImpl = new Optimizer.SGD(options);
+            } else if(optimizerName.toLowerCase().equals("adadelta")) {
+                optimizerImpl = new AdaDelta(ndims, options);
+            } else if(optimizerName.toLowerCase().equals("adagrad")) {
+                optimizerImpl = new AdaGrad(ndims, options);
+            } else if(optimizerName.toLowerCase().equals("adam")) {
+                optimizerImpl = new Adam(ndims, options);
+            } else {
+                throw new IllegalArgumentException("Unsupported optimizer name: " + optimizerName);
+            }
+
+            logger.info("set " + optimizerImpl.getClass().getSimpleName()
+                    + " as an optimizer: " + options);
+
+            // If a regularization type is "RDA", wrap the optimizer with `Optimizer#RDA`.
+            if(options.get("regularization") != null
+                    && options.get("regularization").toLowerCase().equals("rda")) {
+                optimizerImpl = new RDA(ndims, optimizerImpl, options);
+            }
+
+            return optimizerImpl;
+        }
+        throw new IllegalArgumentException("`optimizer` not defined");
+    }
+
+    @NotThreadSafe
+    static final class AdaDelta extends Optimizer.AdaDelta {
+
+        private final OpenHashMap<Object, IWeightValue> auxWeights;
+
+        public AdaDelta(int size, Map<String, String> options) {
+            super(options);
+            this.auxWeights = new OpenHashMap<Object, IWeightValue>(size);
+        }
+
+        @Override
+        public float computeUpdatedValue(@Nonnull Object feature, float weight, float gradient) {
+            IWeightValue auxWeight;
+            if(auxWeights.containsKey(feature)) {
+                auxWeight = auxWeights.get(feature);
+                auxWeight.set(weight);
+            } else {
+                auxWeight = new WeightValue.WeightValueParamsF2(weight, 0.f, 0.f);
+                auxWeights.put(feature, auxWeight);
+            }
+            computeUpdateValue(auxWeight, gradient);
+            return auxWeight.get();
+        }
+
+    }
+
+    @NotThreadSafe
+    static final class AdaGrad extends Optimizer.AdaGrad {
+
+        private final OpenHashMap<Object, IWeightValue> auxWeights;
+
+        public AdaGrad(int size, Map<String, String> options) {
+            super(options);
+            this.auxWeights = new OpenHashMap<Object, IWeightValue>(size);
+        }
+
+        @Override
+        public float computeUpdatedValue(@Nonnull Object feature, float weight, float gradient) {
+            IWeightValue auxWeight;
+            if(auxWeights.containsKey(feature)) {
+                auxWeight = auxWeights.get(feature);
+                auxWeight.set(weight);
+            } else {
+                auxWeight = new WeightValue.WeightValueParamsF2(weight, 0.f, 0.f);
+                auxWeights.put(feature, auxWeight);
+            }
+            computeUpdateValue(auxWeight, gradient);
+            return auxWeight.get();
+        }
+
+    }
+
+    @NotThreadSafe
+    static final class Adam extends Optimizer.Adam {
+
+        private final OpenHashMap<Object, IWeightValue> auxWeights;
+
+        public Adam(int size, Map<String, String> options) {
+            super(options);
+            this.auxWeights = new OpenHashMap<Object, IWeightValue>(size);
+        }
+
+        @Override
+        public float computeUpdatedValue(@Nonnull Object feature, float weight, float gradient) {
+            IWeightValue auxWeight;
+            if(auxWeights.containsKey(feature)) {
+                auxWeight = auxWeights.get(feature);
+                auxWeight.set(weight);
+            } else {
+                auxWeight = new WeightValue.WeightValueParamsF2(weight, 0.f, 0.f);
+                auxWeights.put(feature, auxWeight);
+            }
+            computeUpdateValue(auxWeight, gradient);
+            return auxWeight.get();
+        }
+
+    }
+
+    @NotThreadSafe
+    static final class RDA extends Optimizer.RDA {
+
+        private final OpenHashMap<Object, IWeightValue> auxWeights;
+
+        public RDA(int size, OptimizerBase optimizerImpl, Map<String, String> options) {
+            super(optimizerImpl, options);
+            this.auxWeights = new OpenHashMap<Object, IWeightValue>(size);
+        }
+
+        @Override
+        public float computeUpdatedValue(@Nonnull Object feature, float weight, float gradient) {
+            IWeightValue auxWeight;
+            if(auxWeights.containsKey(feature)) {
+                auxWeight = auxWeights.get(feature);
+                auxWeight.set(weight);
+            } else {
+                auxWeight = new WeightValue.WeightValueParamsF2(weight, 0.f, 0.f);
+                auxWeights.put(feature, auxWeight);
+            }
+            computeUpdateValue(auxWeight, gradient);
+            return auxWeight.get();
+        }
+
+    }
+
+}

--- a/core/src/main/java/hivemall/optimizer/SparseOptimizerFactory.java
+++ b/core/src/main/java/hivemall/optimizer/SparseOptimizerFactory.java
@@ -21,7 +21,7 @@ package hivemall.optimizer;
 import hivemall.model.IWeightValue;
 import hivemall.model.WeightValue;
 import hivemall.optimizer.Optimizer.OptimizerBase;
-import hivemall.utils.collections.OpenHashMap;
+import hivemall.utils.collections.maps.OpenHashMap;
 
 import java.util.Map;
 

--- a/core/src/main/java/hivemall/optimizer/SparseOptimizerFactory.java
+++ b/core/src/main/java/hivemall/optimizer/SparseOptimizerFactory.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.optimizer;
 

--- a/core/src/main/java/hivemall/regression/AROWRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/AROWRegressionUDTF.java
@@ -18,7 +18,7 @@
  */
 package hivemall.regression;
 
-import hivemall.common.LossFunctions;
+import hivemall.optimizer.LossFunctions;
 import hivemall.common.OnlineVariance;
 import hivemall.model.FeatureValue;
 import hivemall.model.IWeightValue;

--- a/core/src/main/java/hivemall/regression/AROWRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/AROWRegressionUDTF.java
@@ -18,12 +18,12 @@
  */
 package hivemall.regression;
 
-import hivemall.optimizer.LossFunctions;
 import hivemall.common.OnlineVariance;
 import hivemall.model.FeatureValue;
 import hivemall.model.IWeightValue;
 import hivemall.model.PredictionResult;
 import hivemall.model.WeightValue.WeightValueWithCovar;
+import hivemall.optimizer.LossFunctions;
 
 import javax.annotation.Nonnull;
 

--- a/core/src/main/java/hivemall/regression/AdaDeltaUDTF.java
+++ b/core/src/main/java/hivemall/regression/AdaDeltaUDTF.java
@@ -18,123 +18,14 @@
  */
 package hivemall.regression;
 
-import hivemall.common.LossFunctions;
-import hivemall.model.FeatureValue;
-import hivemall.model.IWeightValue;
-import hivemall.model.WeightValue.WeightValueParamsF2;
-import hivemall.utils.lang.Primitives;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
-import org.apache.hadoop.hive.ql.exec.Description;
-import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-
 /**
  * ADADELTA: AN ADAPTIVE LEARNING RATE METHOD.
  */
-@Description(
-        name = "train_adadelta_regr",
-        value = "_FUNC_(array<int|bigint|string> features, float target [, constant string options])"
-                + " - Returns a relation consists of <{int|bigint|string} feature, float weight>")
-public final class AdaDeltaUDTF extends RegressionBaseUDTF {
+@Deprecated
+public final class AdaDeltaUDTF extends GeneralRegressionUDTF {
 
-    private float decay;
-    private float eps;
-    private float scaling;
-
-    @Override
-    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
-        final int numArgs = argOIs.length;
-        if (numArgs != 2 && numArgs != 3) {
-            throw new UDFArgumentException(
-                "AdaDeltaUDTF takes 2 or 3 arguments: List<Text|Int|BitInt> features, float target [, constant string options]");
-        }
-
-        StructObjectInspector oi = super.initialize(argOIs);
-        model.configureParams(true, true, false);
-        return oi;
-    }
-
-    @Override
-    protected Options getOptions() {
-        Options opts = super.getOptions();
-        opts.addOption("rho", "decay", true, "Decay rate [default 0.95]");
-        opts.addOption("eps", true, "A constant used in the denominator of AdaGrad [default 1e-6]");
-        opts.addOption("scale", true,
-            "Internal scaling/descaling factor for cumulative weights [100]");
-        return opts;
-    }
-
-    @Override
-    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
-        CommandLine cl = super.processOptions(argOIs);
-        if (cl == null) {
-            this.decay = 0.95f;
-            this.eps = 1e-6f;
-            this.scaling = 100f;
-        } else {
-            this.decay = Primitives.parseFloat(cl.getOptionValue("decay"), 0.95f);
-            this.eps = Primitives.parseFloat(cl.getOptionValue("eps"), 1E-6f);
-            this.scaling = Primitives.parseFloat(cl.getOptionValue("scale"), 100f);
-        }
-        return cl;
-    }
-
-    @Override
-    protected final void checkTargetValue(final float target) throws UDFArgumentException {
-        if (target < 0.f || target > 1.f) {
-            throw new UDFArgumentException("target must be in range 0 to 1: " + target);
-        }
-    }
-
-    @Override
-    protected void update(@Nonnull final FeatureValue[] features, float target, float predicted) {
-        float gradient = LossFunctions.logisticLoss(target, predicted);
-        onlineUpdate(features, gradient);
-    }
-
-    @Override
-    protected void onlineUpdate(@Nonnull final FeatureValue[] features, float gradient) {
-        final float g_g = gradient * (gradient / scaling);
-
-        for (FeatureValue f : features) {// w[i] += y * x[i]
-            if (f == null) {
-                continue;
-            }
-            Object x = f.getFeature();
-            float xi = f.getValueAsFloat();
-
-            IWeightValue old_w = model.get(x);
-            IWeightValue new_w = getNewWeight(old_w, xi, gradient, g_g);
-            model.set(x, new_w);
-        }
-    }
-
-    @Nonnull
-    protected IWeightValue getNewWeight(@Nullable final IWeightValue old, final float xi,
-            final float gradient, final float g_g) {
-        float old_w = 0.f;
-        float old_scaled_sum_sqgrad = 0.f;
-        float old_sum_squared_delta_x = 0.f;
-        if (old != null) {
-            old_w = old.get();
-            old_scaled_sum_sqgrad = old.getSumOfSquaredGradients();
-            old_sum_squared_delta_x = old.getSumOfSquaredDeltaX();
-        }
-
-        float new_scaled_sum_sq_grad = (decay * old_scaled_sum_sqgrad) + ((1.f - decay) * g_g);
-        float dx = (float) Math.sqrt((old_sum_squared_delta_x + eps)
-                / (old_scaled_sum_sqgrad * scaling + eps))
-                * gradient;
-        float new_sum_squared_delta_x = (decay * old_sum_squared_delta_x)
-                + ((1.f - decay) * dx * dx);
-        float new_w = old_w + (dx * xi);
-        return new WeightValueParamsF2(new_w, new_scaled_sum_sq_grad, new_sum_squared_delta_x);
+    public AdaDeltaUDTF() {
+        optimizerOptions.put("optimizer", "AdaDelta");
     }
 
 }

--- a/core/src/main/java/hivemall/regression/AdaDeltaUDTF.java
+++ b/core/src/main/java/hivemall/regression/AdaDeltaUDTF.java
@@ -18,14 +18,126 @@
  */
 package hivemall.regression;
 
+import hivemall.model.FeatureValue;
+import hivemall.model.IWeightValue;
+import hivemall.model.WeightValue.WeightValueParamsF2;
+import hivemall.optimizer.LossFunctions;
+import hivemall.utils.lang.Primitives;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+
 /**
  * ADADELTA: AN ADAPTIVE LEARNING RATE METHOD.
+ *
+ * @deprecated Use {@link hivemall.regression.GeneralRegressionUDTF} instead
  */
 @Deprecated
-public final class AdaDeltaUDTF extends GeneralRegressionUDTF {
+@Description(
+        name = "train_adadelta_regr",
+        value = "_FUNC_(array<int|bigint|string> features, float target [, constant string options])"
+                + " - Returns a relation consists of <{int|bigint|string} feature, float weight>")
+public final class AdaDeltaUDTF extends RegressionBaseUDTF {
 
-    public AdaDeltaUDTF() {
-        optimizerOptions.put("optimizer", "AdaDelta");
+    private float decay;
+    private float eps;
+    private float scaling;
+
+    @Override
+    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        final int numArgs = argOIs.length;
+        if (numArgs != 2 && numArgs != 3) {
+            throw new UDFArgumentException(
+                "AdaDeltaUDTF takes 2 or 3 arguments: List<Text|Int|BitInt> features, float target [, constant string options]");
+        }
+
+        StructObjectInspector oi = super.initialize(argOIs);
+        model.configureParams(true, true, false);
+        return oi;
+    }
+
+    @Override
+    protected Options getOptions() {
+        Options opts = super.getOptions();
+        opts.addOption("rho", "decay", true, "Decay rate [default 0.95]");
+        opts.addOption("eps", true, "A constant used in the denominator of AdaGrad [default 1e-6]");
+        opts.addOption("scale", true,
+            "Internal scaling/descaling factor for cumulative weights [100]");
+        return opts;
+    }
+
+    @Override
+    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
+        CommandLine cl = super.processOptions(argOIs);
+        if (cl == null) {
+            this.decay = 0.95f;
+            this.eps = 1e-6f;
+            this.scaling = 100f;
+        } else {
+            this.decay = Primitives.parseFloat(cl.getOptionValue("decay"), 0.95f);
+            this.eps = Primitives.parseFloat(cl.getOptionValue("eps"), 1E-6f);
+            this.scaling = Primitives.parseFloat(cl.getOptionValue("scale"), 100f);
+        }
+        return cl;
+    }
+
+    @Override
+    protected final void checkTargetValue(final float target) throws UDFArgumentException {
+        if (target < 0.f || target > 1.f) {
+            throw new UDFArgumentException("target must be in range 0 to 1: " + target);
+        }
+    }
+
+    @Override
+    protected void update(@Nonnull final FeatureValue[] features, float target, float predicted) {
+        float gradient = LossFunctions.logisticLoss(target, predicted);
+        onlineUpdate(features, gradient);
+    }
+
+    @Override
+    protected void onlineUpdate(@Nonnull final FeatureValue[] features, float gradient) {
+        final float g_g = gradient * (gradient / scaling);
+
+        for (FeatureValue f : features) {// w[i] += y * x[i]
+            if (f == null) {
+                continue;
+            }
+            Object x = f.getFeature();
+            float xi = f.getValueAsFloat();
+
+            IWeightValue old_w = model.get(x);
+            IWeightValue new_w = getNewWeight(old_w, xi, gradient, g_g);
+            model.set(x, new_w);
+        }
+    }
+
+    @Nonnull
+    protected IWeightValue getNewWeight(@Nullable final IWeightValue old, final float xi,
+            final float gradient, final float g_g) {
+        float old_w = 0.f;
+        float old_scaled_sum_sqgrad = 0.f;
+        float old_sum_squared_delta_x = 0.f;
+        if (old != null) {
+            old_w = old.get();
+            old_scaled_sum_sqgrad = old.getSumOfSquaredGradients();
+            old_sum_squared_delta_x = old.getSumOfSquaredDeltaX();
+        }
+
+        float new_scaled_sum_sq_grad = (decay * old_scaled_sum_sqgrad) + ((1.f - decay) * g_g);
+        float dx = (float) Math.sqrt((old_sum_squared_delta_x + eps)
+                / (old_scaled_sum_sqgrad * scaling + eps))
+                * gradient;
+        float new_sum_squared_delta_x = (decay * old_sum_squared_delta_x)
+                + ((1.f - decay) * dx * dx);
+        float new_w = old_w + (dx * xi);
+        return new WeightValueParamsF2(new_w, new_scaled_sum_sq_grad, new_sum_squared_delta_x);
     }
 
 }

--- a/core/src/main/java/hivemall/regression/AdaGradUDTF.java
+++ b/core/src/main/java/hivemall/regression/AdaGradUDTF.java
@@ -18,124 +18,14 @@
  */
 package hivemall.regression;
 
-import hivemall.common.LossFunctions;
-import hivemall.model.FeatureValue;
-import hivemall.model.IWeightValue;
-import hivemall.model.WeightValue.WeightValueParamsF1;
-import hivemall.utils.lang.Primitives;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
-import org.apache.hadoop.hive.ql.exec.Description;
-import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-
 /**
  * ADAGRAD algorithm with element-wise adaptive learning rates.
  */
-@Description(
-        name = "train_adagrad_regr",
-        value = "_FUNC_(array<int|bigint|string> features, float target [, constant string options])"
-                + " - Returns a relation consists of <{int|bigint|string} feature, float weight>")
-public final class AdaGradUDTF extends RegressionBaseUDTF {
+@Deprecated
+public final class AdaGradUDTF extends GeneralRegressionUDTF {
 
-    private float eta;
-    private float eps;
-    private float scaling;
-
-    @Override
-    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
-        final int numArgs = argOIs.length;
-        if (numArgs != 2 && numArgs != 3) {
-            throw new UDFArgumentException(
-                "_FUNC_ takes 2 or 3 arguments: List<Text|Int|BitInt> features, float target [, constant string options]");
-        }
-
-        StructObjectInspector oi = super.initialize(argOIs);
-        model.configureParams(true, false, false);
-        return oi;
-    }
-
-    @Override
-    protected Options getOptions() {
-        Options opts = super.getOptions();
-        opts.addOption("eta", "eta0", true, "The initial learning rate [default 1.0]");
-        opts.addOption("eps", true, "A constant used in the denominator of AdaGrad [default 1.0]");
-        opts.addOption("scale", true,
-            "Internal scaling/descaling factor for cumulative weights [100]");
-        return opts;
-    }
-
-    @Override
-    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
-        CommandLine cl = super.processOptions(argOIs);
-        if (cl == null) {
-            this.eta = 1.f;
-            this.eps = 1.f;
-            this.scaling = 100f;
-        } else {
-            this.eta = Primitives.parseFloat(cl.getOptionValue("eta"), 1.f);
-            this.eps = Primitives.parseFloat(cl.getOptionValue("eps"), 1.f);
-            this.scaling = Primitives.parseFloat(cl.getOptionValue("scale"), 100f);
-        }
-        return cl;
-    }
-
-    @Override
-    protected final void checkTargetValue(final float target) throws UDFArgumentException {
-        if (target < 0.f || target > 1.f) {
-            throw new UDFArgumentException("target must be in range 0 to 1: " + target);
-        }
-    }
-
-    @Override
-    protected void update(@Nonnull final FeatureValue[] features, float target, float predicted) {
-        float gradient = LossFunctions.logisticLoss(target, predicted);
-        onlineUpdate(features, gradient);
-    }
-
-    @Override
-    protected void onlineUpdate(@Nonnull final FeatureValue[] features, float gradient) {
-        final float g_g = gradient * (gradient / scaling);
-
-        for (FeatureValue f : features) {// w[i] += y * x[i]
-            if (f == null) {
-                continue;
-            }
-            Object x = f.getFeature();
-            float xi = f.getValueAsFloat();
-
-            IWeightValue old_w = model.get(x);
-            IWeightValue new_w = getNewWeight(old_w, xi, gradient, g_g);
-            model.set(x, new_w);
-        }
-    }
-
-    @Nonnull
-    protected IWeightValue getNewWeight(@Nullable final IWeightValue old, final float xi,
-            final float gradient, final float g_g) {
-        float old_w = 0.f;
-        float scaled_sum_sqgrad = 0.f;
-
-        if (old != null) {
-            old_w = old.get();
-            scaled_sum_sqgrad = old.getSumOfSquaredGradients();
-        }
-        scaled_sum_sqgrad += g_g;
-
-        float coeff = eta(scaled_sum_sqgrad) * gradient;
-        float new_w = old_w + (coeff * xi);
-        return new WeightValueParamsF1(new_w, scaled_sum_sqgrad);
-    }
-
-    protected float eta(final double scaledSumOfSquaredGradients) {
-        double sumOfSquaredGradients = scaledSumOfSquaredGradients * scaling;
-        //return eta / (float) Math.sqrt(sumOfSquaredGradients);
-        return eta / (float) Math.sqrt(eps + sumOfSquaredGradients); // always less than eta0
+    public AdaGradUDTF() {
+        optimizerOptions.put("optimizer", "AdaGrad");
     }
 
 }

--- a/core/src/main/java/hivemall/regression/AdaGradUDTF.java
+++ b/core/src/main/java/hivemall/regression/AdaGradUDTF.java
@@ -18,14 +18,127 @@
  */
 package hivemall.regression;
 
+import hivemall.model.FeatureValue;
+import hivemall.model.IWeightValue;
+import hivemall.model.WeightValue.WeightValueParamsF1;
+import hivemall.optimizer.LossFunctions;
+import hivemall.utils.lang.Primitives;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+
 /**
  * ADAGRAD algorithm with element-wise adaptive learning rates.
+ *
+ * @deprecated Use {@link hivemall.regression.GeneralRegressionUDTF} instead
  */
 @Deprecated
-public final class AdaGradUDTF extends GeneralRegressionUDTF {
+@Description(
+        name = "train_adagrad_regr",
+        value = "_FUNC_(array<int|bigint|string> features, float target [, constant string options])"
+                + " - Returns a relation consists of <{int|bigint|string} feature, float weight>")
+public final class AdaGradUDTF extends RegressionBaseUDTF {
 
-    public AdaGradUDTF() {
-        optimizerOptions.put("optimizer", "AdaGrad");
+    private float eta;
+    private float eps;
+    private float scaling;
+
+    @Override
+    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        final int numArgs = argOIs.length;
+        if (numArgs != 2 && numArgs != 3) {
+            throw new UDFArgumentException(
+                "_FUNC_ takes 2 or 3 arguments: List<Text|Int|BitInt> features, float target [, constant string options]");
+        }
+
+        StructObjectInspector oi = super.initialize(argOIs);
+        model.configureParams(true, false, false);
+        return oi;
+    }
+
+    @Override
+    protected Options getOptions() {
+        Options opts = super.getOptions();
+        opts.addOption("eta", "eta0", true, "The initial learning rate [default 1.0]");
+        opts.addOption("eps", true, "A constant used in the denominator of AdaGrad [default 1.0]");
+        opts.addOption("scale", true,
+            "Internal scaling/descaling factor for cumulative weights [100]");
+        return opts;
+    }
+
+    @Override
+    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
+        CommandLine cl = super.processOptions(argOIs);
+        if (cl == null) {
+            this.eta = 1.f;
+            this.eps = 1.f;
+            this.scaling = 100f;
+        } else {
+            this.eta = Primitives.parseFloat(cl.getOptionValue("eta"), 1.f);
+            this.eps = Primitives.parseFloat(cl.getOptionValue("eps"), 1.f);
+            this.scaling = Primitives.parseFloat(cl.getOptionValue("scale"), 100f);
+        }
+        return cl;
+    }
+
+    @Override
+    protected final void checkTargetValue(final float target) throws UDFArgumentException {
+        if (target < 0.f || target > 1.f) {
+            throw new UDFArgumentException("target must be in range 0 to 1: " + target);
+        }
+    }
+
+    @Override
+    protected void update(@Nonnull final FeatureValue[] features, float target, float predicted) {
+        float gradient = LossFunctions.logisticLoss(target, predicted);
+        onlineUpdate(features, gradient);
+    }
+
+    @Override
+    protected void onlineUpdate(@Nonnull final FeatureValue[] features, float gradient) {
+        final float g_g = gradient * (gradient / scaling);
+
+        for (FeatureValue f : features) {// w[i] += y * x[i]
+            if (f == null) {
+                continue;
+            }
+            Object x = f.getFeature();
+            float xi = f.getValueAsFloat();
+
+            IWeightValue old_w = model.get(x);
+            IWeightValue new_w = getNewWeight(old_w, xi, gradient, g_g);
+            model.set(x, new_w);
+        }
+    }
+
+    @Nonnull
+    protected IWeightValue getNewWeight(@Nullable final IWeightValue old, final float xi,
+            final float gradient, final float g_g) {
+        float old_w = 0.f;
+        float scaled_sum_sqgrad = 0.f;
+
+        if (old != null) {
+            old_w = old.get();
+            scaled_sum_sqgrad = old.getSumOfSquaredGradients();
+        }
+        scaled_sum_sqgrad += g_g;
+
+        float coeff = eta(scaled_sum_sqgrad) * gradient;
+        float new_w = old_w + (coeff * xi);
+        return new WeightValueParamsF1(new_w, scaled_sum_sqgrad);
+    }
+
+    protected float eta(final double scaledSumOfSquaredGradients) {
+        double sumOfSquaredGradients = scaledSumOfSquaredGradients * scaling;
+        //return eta / (float) Math.sqrt(sumOfSquaredGradients);
+        return eta / (float) Math.sqrt(eps + sumOfSquaredGradients); // always less than eta0
     }
 
 }

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -40,6 +40,7 @@ public class GeneralRegressionUDTF extends RegressionBaseUDTF {
     protected final Map<String, String> optimizerOptions;
 
     public GeneralRegressionUDTF() {
+        super(true); // This enables new model interfaces
         this.optimizerOptions = new HashMap<String, String>();
         // Set default values
         optimizerOptions.put("optimizer", "adadelta");

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.regression;
 

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -110,12 +110,12 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
     @Override
     protected void update(@Nonnull final FeatureValue[] features, final float target,
             final float predicted) {
-        float loss = lossFunction.loss(target, predicted);
+        float dloss = lossFunction.dloss(predicted, target);
         for (FeatureValue f : features) {
             Object feature = f.getFeature();
             float xi = f.getValueAsFloat();
             float weight = model.getWeight(feature);
-            float new_weight = optimizer.update(feature, weight, -loss * xi);
+            float new_weight = optimizer.update(feature, weight, dloss * xi);
             model.setWeight(feature, new_weight);
         }
         optimizer.proceedStep();

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -1,0 +1,125 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.regression;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+
+import hivemall.optimizer.LossFunctions;
+import hivemall.model.FeatureValue;
+
+/**
+ * A general regression class with replaceable optimization functions.
+ */
+public class GeneralRegressionUDTF extends RegressionBaseUDTF {
+
+    protected final Map<String, String> optimizerOptions;
+
+    public GeneralRegressionUDTF() {
+        this.optimizerOptions = new HashMap<String, String>();
+        // Set default values
+        optimizerOptions.put("optimizer", "adadelta");
+        optimizerOptions.put("eta", "fixed");
+        optimizerOptions.put("eta0", "1.0");
+        optimizerOptions.put("t", "10000");
+        optimizerOptions.put("power_t", "0.1");
+        optimizerOptions.put("eps", "1e-6");
+        optimizerOptions.put("rho", "0.95");
+        optimizerOptions.put("scale", "100.0");
+        optimizerOptions.put("lambda", "1.0");
+    }
+
+    @Override
+    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        if(argOIs.length != 2 && argOIs.length != 3) {
+            throw new UDFArgumentException(
+                    this.getClass().getSimpleName()
+                  + " takes 2 or 3 arguments: List<Text|Int|BitInt> features, float target "
+                  + "[, constant string options]");
+        }
+        return super.initialize(argOIs);
+    }
+
+    @Override
+    protected Options getOptions() {
+        Options opts = super.getOptions();
+        opts.addOption("optimizer", "opt", true, "Optimizer to update weights [default: adadelta]");
+        opts.addOption("eta", true, " ETA estimator to compute delta [default: fixed]");
+        opts.addOption("eta0", true, "Initial learning rate [default 1.0]");
+        opts.addOption("t", "total_steps", true, "Total of n_samples * epochs time steps [default: 10000]");
+        opts.addOption("power_t", true, "Exponent for inverse scaling learning rate [default 0.1]");
+        opts.addOption("eps", true, "Denominator value of AdaDelta/AdaGrad [default 1e-6]");
+        opts.addOption("rho", "decay", true, "Decay rate [default 0.95]");
+        opts.addOption("scale", true, "Scaling factor for cumulative weights [100.0]");
+        opts.addOption("regularization", "reg", true, "Regularization type [default not-defined]");
+        opts.addOption("lambda", true, "Regularization term on weights [default 1.0]");
+        return opts;
+    }
+
+    @Override
+    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
+        final CommandLine cl = super.processOptions(argOIs);
+        if(cl != null) {
+            for(final Option opt: cl.getOptions()) {
+                optimizerOptions.put(opt.getOpt(), opt.getValue());
+            }
+        }
+        return cl;
+    }
+
+    @Override
+    protected Map<String, String> getOptimzierOptions() {
+        return optimizerOptions;
+    }
+
+    @Override
+    protected final void checkTargetValue(final float target) throws UDFArgumentException {
+        if(target < 0.f || target > 1.f) {
+            throw new UDFArgumentException("target must be in range 0 to 1: " + target);
+        }
+    }
+
+    @Override
+    protected void update(@Nonnull final FeatureValue[] features, final float target,
+            final float predicted) {
+        if(is_mini_batch) {
+            throw new UnsupportedOperationException(
+                    this.getClass().getSimpleName() + " supports no `is_mini_batch` mode");
+        } else {
+            float loss = LossFunctions.logisticLoss(target, predicted);
+            for(FeatureValue f : features) {
+                Object feature = f.getFeature();
+                float xi = f.getValueAsFloat();
+                float weight = model.getWeight(feature);
+                float new_weight = optimizerImpl.computeUpdatedValue(feature, weight, -loss * xi);
+                model.setWeight(feature, new_weight);
+            }
+            optimizerImpl.proceedStep();
+        }
+    }
+
+}

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -86,7 +86,7 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
     protected Options getOptions() {
         Options opts = super.getOptions();
         opts.addOption("loss", "loss_function", true,
-                "Loss function [default: SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss]");
+                "Loss function [default: SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss]");
         OptimizerOptions.setup(opts);
         return opts;
     }

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -19,6 +19,7 @@
 package hivemall.regression;
 
 import hivemall.annotations.Since;
+import hivemall.annotations.VisibleForTesting;
 import hivemall.model.FeatureValue;
 import hivemall.optimizer.LossFunctions;
 import hivemall.optimizer.LossFunctions.LossFunction;
@@ -51,6 +52,8 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
     private final Map<String, String> optimizerOptions;
     private Optimizer optimizer;
     private LossFunction lossFunction;
+
+    private float loss;
 
     public GeneralRegressionUDTF() {
         super(true); // This enables new model interfaces
@@ -113,6 +116,8 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
     @Override
     protected void update(@Nonnull final FeatureValue[] features, final float target,
             final float predicted) {
+        this.loss = lossFunction.loss(predicted, target);
+
         float dloss = lossFunction.dloss(predicted, target);
         for (FeatureValue f : features) {
             Object feature = f.getFeature();
@@ -122,6 +127,11 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
             model.setWeight(feature, new_weight);
         }
         optimizer.proceedStep();
+    }
+
+    @VisibleForTesting
+    float getLoss() {
+        return loss;
     }
 
 }

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -18,27 +18,16 @@
  */
 package hivemall.regression;
 
+import hivemall.GeneralLearnerBaseUDTF;
 import hivemall.annotations.Since;
-import hivemall.annotations.VisibleForTesting;
 import hivemall.model.FeatureValue;
-import hivemall.optimizer.LossFunctions;
 import hivemall.optimizer.LossFunctions.LossFunction;
 import hivemall.optimizer.LossFunctions.LossType;
-import hivemall.optimizer.Optimizer;
-import hivemall.optimizer.Optimizer.OptimizerBase;
-import hivemall.optimizer.OptimizerOptions;
-import hivemall.utils.lang.FloatAccumulator;
-
-import java.util.Map;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 
 /**
  * A general regression class with replaceable optimization functions.
@@ -48,153 +37,33 @@ import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
                 + " - Returns a relation consists of <string|int|bigint feature, float weight>",
         extended = "Build a prediction model by a generic regressor")
 @Since(version = "0.5-rc.1")
-public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
+public final class GeneralRegressionUDTF extends GeneralLearnerBaseUDTF {
 
-    @Nonnull
-    private final Map<String, String> optimizerOptions;
-    private Optimizer optimizer;
-    private LossFunction lossFunction;
-
-    private float cumLoss;
-
-    public GeneralRegressionUDTF() {
-        super(true); // This enables new model interfaces
-        this.optimizerOptions = OptimizerOptions.create();
+    @Override
+    protected String getLossOptionDescription() {
+        return "Loss function [default: SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss]";
     }
 
     @Override
-    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
-        if (argOIs.length != 2 && argOIs.length != 3) {
-            throw new UDFArgumentException(this.getClass().getSimpleName()
-                    + " takes 2 or 3 arguments: List<Text|Int|BitInt> features, float target "
-                    + "[, constant string options]");
-        }
+    protected LossType getDefaultLossType() {
+        return LossType.SquaredLoss;
+    }
 
-        StructObjectInspector outputOI = super.initialize(argOIs);
-
+    @Override
+    protected void checkLossFunction(LossFunction lossFunction) throws UDFArgumentException {
         if (lossFunction.forBinaryClassification()) {
             throw new UDFArgumentException("The loss function `" + lossFunction.getType()
                     + "` is not designed for regression");
-
-        }
-
-        try {
-            this.optimizer = createOptimizer(optimizerOptions);
-        } catch (Throwable e) {
-            throw new UDFArgumentException(e.getMessage());
-        }
-
-        if ((optimizer instanceof OptimizerBase.AdagradRDA) && is_mini_batch) {
-            throw new UDFArgumentException("Currently `-mini_batch` option is NOT available for AdaGradRDA");
-        }
-
-        this.cumLoss = 0.f;
-
-        return outputOI;
-    }
-
-    @Override
-    protected Options getOptions() {
-        Options opts = super.getOptions();
-        opts.addOption("loss", "loss_function", true,
-            "Loss function [default: SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss]");
-        OptimizerOptions.setup(opts);
-        return opts;
-    }
-
-    @Override
-    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
-        CommandLine cl = super.processOptions(argOIs);
-        if (cl.hasOption("loss_function")) {
-            try {
-                this.lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
-            } catch (Throwable e) {
-                throw new UDFArgumentException(e.getMessage());
-            }
-        } else {
-            this.lossFunction = LossFunctions.getLossFunction(LossType.SquaredLoss);
-        }
-        OptimizerOptions.propcessOptions(cl, optimizerOptions);
-        return cl;
-    }
-
-    @Override
-    protected void update(@Nonnull final FeatureValue[] features, final float target,
-            final float predicted) {
-        this.cumLoss += lossFunction.loss(predicted, target); // retain cumulative loss to check convergence
-        float dloss = lossFunction.dloss(predicted, target);
-        if (is_mini_batch) {
-            accumulateUpdate(features, dloss);
-            if (sampled >= mini_batch_size) {
-                batchUpdate();
-            }
-        } else {
-            onlineUpdate(features, dloss);
         }
     }
 
     @Override
-    protected void accumulateUpdate(@Nonnull final FeatureValue[] features, final float dloss) {
-        for (FeatureValue f : features) {
-            Object feature = f.getFeature();
-            float xi = f.getValueAsFloat();
-            float weight = model.getWeight(feature);
-
-            // compute new weight, but still not set to the model
-            float new_weight = optimizer.update(feature, weight, dloss * xi);
-
-            // (w_i - eta * delta_1) + (w_i - eta * delta_2) + ... + (w_i - eta * delta_M)
-            FloatAccumulator acc = accumulated.get(feature);
-            if (acc == null) {
-                acc = new FloatAccumulator(new_weight);
-                accumulated.put(feature, acc);
-            } else {
-                acc.add(new_weight);
-            }
-        }
-        sampled++;
-    }
+    protected void checkTargetValue(float label) throws UDFArgumentException {}
 
     @Override
-    protected void batchUpdate() {
-        if (accumulated.isEmpty()) {
-            this.sampled = 0;
-            return;
-        }
-
-        for (Map.Entry<Object, FloatAccumulator> e : accumulated.entrySet()) {
-            Object feature = e.getKey();
-            FloatAccumulator v = e.getValue();
-            float new_weight = v.get(); // w_i - (eta / M) * (delta_1 + delta_2 + ... + delta_M)
-            model.setWeight(feature, new_weight);
-        }
-
-        optimizer.proceedStep();
-
-        accumulated.clear();
-        this.sampled = 0;
-    }
-
-    @Override
-    protected void onlineUpdate(@Nonnull final FeatureValue[] features, float dloss) {
-        for (FeatureValue f : features) {
-            Object feature = f.getFeature();
-            float xi = f.getValueAsFloat();
-            float weight = model.getWeight(feature);
-            float new_weight = optimizer.update(feature, weight, dloss * xi);
-            model.setWeight(feature, new_weight);
-        }
-        optimizer.proceedStep();
-    }
-
-    @VisibleForTesting
-    float getCumulativeLoss() {
-        return cumLoss;
-    }
-
-    @VisibleForTesting
-    void resetCumulativeLoss() {
-        this.cumLoss = 0.f;
+    protected void train(@Nonnull final FeatureValue[] features, final float target) {
+        float p = predict(features);
+        update(features, target, p);
     }
 
 }

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -73,7 +73,12 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
             throw new UDFArgumentException("_FUNC_ does not currently support `-mini_batch` option");
         }
 
-        this.optimizer = createOptimizer(optimizerOptions);
+        try {
+            this.optimizer = createOptimizer(optimizerOptions);
+        } catch (Throwable e) {
+            throw new UDFArgumentException(e.getMessage());
+        }
+
         return outputOI;
     }
 
@@ -89,10 +94,14 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
     @Override
     protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
         CommandLine cl = super.processOptions(argOIs);
-        if (cl.hasOption("loss_function")) {
-            this.lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
-        } else {
-            this.lossFunction = LossFunctions.getLossFunction("SquaredLoss");
+        try {
+            if (cl.hasOption("loss_function")) {
+                this.lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
+            } else {
+                this.lossFunction = LossFunctions.getLossFunction("SquaredLoss");
+            }
+        } catch (Throwable e) {
+            throw new UDFArgumentException(e.getMessage());
         }
         OptimizerOptions.propcessOptions(cl, optimizerOptions);
         return cl;

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -108,13 +108,6 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
     }
 
     @Override
-    protected final void checkTargetValue(final float target) throws UDFArgumentException {
-        if (target < 0.f || target > 1.f) {
-            throw new UDFArgumentException("target must be in range 0 to 1: " + target);
-        }
-    }
-
-    @Override
     protected void update(@Nonnull final FeatureValue[] features, final float target,
             final float predicted) {
         float loss = lossFunction.loss(target, predicted);

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -67,7 +67,9 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
         StructObjectInspector outputOI = super.initialize(argOIs);
 
         if (lossFunction.forBinaryClassification()) {
-            throw new UDFArgumentException("The loss function `" + lossFunction + "` is not for regression");
+            throw new UDFArgumentException("The loss function `" + lossFunction.getType()
+                    + "` is not designed for regression");
+
         }
         if (is_mini_batch) {
             throw new UDFArgumentException("_FUNC_ does not currently support `-mini_batch` option");

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -22,6 +22,7 @@ import hivemall.annotations.Since;
 import hivemall.model.FeatureValue;
 import hivemall.optimizer.LossFunctions;
 import hivemall.optimizer.LossFunctions.LossFunction;
+import hivemall.optimizer.LossFunctions.LossType;
 import hivemall.optimizer.Optimizer;
 import hivemall.optimizer.OptimizerOptions;
 
@@ -88,7 +89,7 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
     protected Options getOptions() {
         Options opts = super.getOptions();
         opts.addOption("loss", "loss_function", true,
-                "Loss function [default: SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss]");
+            "Loss function [default: SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss]");
         OptimizerOptions.setup(opts);
         return opts;
     }
@@ -96,14 +97,14 @@ public final class GeneralRegressionUDTF extends RegressionBaseUDTF {
     @Override
     protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
         CommandLine cl = super.processOptions(argOIs);
-        try {
-            if (cl.hasOption("loss_function")) {
+        if (cl.hasOption("loss_function")) {
+            try {
                 this.lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
-            } else {
-                this.lossFunction = LossFunctions.getLossFunction("SquaredLoss");
+            } catch (Throwable e) {
+                throw new UDFArgumentException(e.getMessage());
             }
-        } catch (Throwable e) {
-            throw new UDFArgumentException(e.getMessage());
+        } else {
+            this.lossFunction = LossFunctions.getLossFunction(LossType.SquaredLoss);
         }
         OptimizerOptions.propcessOptions(cl, optimizerOptions);
         return cl;

--- a/core/src/main/java/hivemall/regression/LogressUDTF.java
+++ b/core/src/main/java/hivemall/regression/LogressUDTF.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 
 /**
+ * Logistic regression using SGD.
+ * 
  * @deprecated Use {@link hivemall.regression.GeneralRegressionUDTF} instead
  */
 @Deprecated
@@ -54,7 +56,8 @@ public final class LogressUDTF extends RegressionBaseUDTF {
     @Override
     protected Options getOptions() {
         Options opts = super.getOptions();
-        opts.addOption("t", "total_steps", true, "a total of n_samples * epochs time steps");
+        opts.addOption("t", "total_steps", true,
+            "a total of n_samples * epochs time steps [default: 10000]");
         opts.addOption("power_t", true,
             "The exponent for inverse scaling learning rate [default 0.1]");
         opts.addOption("eta0", true, "The initial learning rate [default 0.1]");

--- a/core/src/main/java/hivemall/regression/LogressUDTF.java
+++ b/core/src/main/java/hivemall/regression/LogressUDTF.java
@@ -18,65 +18,12 @@
  */
 package hivemall.regression;
 
-import hivemall.common.EtaEstimator;
-import hivemall.common.LossFunctions;
+@Deprecated
+public final class LogressUDTF extends GeneralRegressionUDTF {
 
-import org.apache.commons.cli.CommandLine;
-import org.apache.commons.cli.Options;
-import org.apache.hadoop.hive.ql.exec.Description;
-import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-
-@Description(
-        name = "logress",
-        value = "_FUNC_(array<int|bigint|string> features, float target [, constant string options])"
-                + " - Returns a relation consists of <{int|bigint|string} feature, float weight>")
-public final class LogressUDTF extends RegressionBaseUDTF {
-
-    private EtaEstimator etaEstimator;
-
-    @Override
-    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
-        final int numArgs = argOIs.length;
-        if (numArgs != 2 && numArgs != 3) {
-            throw new UDFArgumentException(
-                "LogressUDTF takes 2 or 3 arguments: List<Text|Int|BitInt> features, float target [, constant string options]");
-        }
-
-        return super.initialize(argOIs);
-    }
-
-    @Override
-    protected Options getOptions() {
-        Options opts = super.getOptions();
-        opts.addOption("t", "total_steps", true, "a total of n_samples * epochs time steps");
-        opts.addOption("power_t", true,
-            "The exponent for inverse scaling learning rate [default 0.1]");
-        opts.addOption("eta0", true, "The initial learning rate [default 0.1]");
-        return opts;
-    }
-
-    @Override
-    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
-        CommandLine cl = super.processOptions(argOIs);
-
-        this.etaEstimator = EtaEstimator.get(cl);
-        return cl;
-    }
-
-    @Override
-    protected void checkTargetValue(final float target) throws UDFArgumentException {
-        if (target < 0.f || target > 1.f) {
-            throw new UDFArgumentException("target must be in range 0 to 1: " + target);
-        }
-    }
-
-    @Override
-    protected float computeUpdate(final float target, final float predicted) {
-        float eta = etaEstimator.eta(count);
-        float gradient = LossFunctions.logisticLoss(target, predicted);
-        return eta * gradient;
+    public LogressUDTF() {
+        optimizerOptions.put("optimizer", "SGD");
+        optimizerOptions.put("eta", "fixed");
     }
 
 }

--- a/core/src/main/java/hivemall/regression/LogressUDTF.java
+++ b/core/src/main/java/hivemall/regression/LogressUDTF.java
@@ -18,12 +18,69 @@
  */
 package hivemall.regression;
 
-@Deprecated
-public final class LogressUDTF extends GeneralRegressionUDTF {
+import hivemall.optimizer.EtaEstimator;
+import hivemall.optimizer.LossFunctions;
 
-    public LogressUDTF() {
-        optimizerOptions.put("optimizer", "SGD");
-        optimizerOptions.put("eta", "fixed");
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+
+/**
+ * @deprecated Use {@link hivemall.regression.GeneralRegressionUDTF} instead
+ */
+@Deprecated
+@Description(
+        name = "logress",
+        value = "_FUNC_(array<int|bigint|string> features, float target [, constant string options])"
+                + " - Returns a relation consists of <{int|bigint|string} feature, float weight>")
+public final class LogressUDTF extends RegressionBaseUDTF {
+
+    private EtaEstimator etaEstimator;
+
+    @Override
+    public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        final int numArgs = argOIs.length;
+        if (numArgs != 2 && numArgs != 3) {
+            throw new UDFArgumentException(
+                "LogressUDTF takes 2 or 3 arguments: List<Text|Int|BitInt> features, float target [, constant string options]");
+        }
+
+        return super.initialize(argOIs);
+    }
+
+    @Override
+    protected Options getOptions() {
+        Options opts = super.getOptions();
+        opts.addOption("t", "total_steps", true, "a total of n_samples * epochs time steps");
+        opts.addOption("power_t", true,
+            "The exponent for inverse scaling learning rate [default 0.1]");
+        opts.addOption("eta0", true, "The initial learning rate [default 0.1]");
+        return opts;
+    }
+
+    @Override
+    protected CommandLine processOptions(ObjectInspector[] argOIs) throws UDFArgumentException {
+        CommandLine cl = super.processOptions(argOIs);
+
+        this.etaEstimator = EtaEstimator.get(cl);
+        return cl;
+    }
+
+    @Override
+    protected void checkTargetValue(final float target) throws UDFArgumentException {
+        if (target < 0.f || target > 1.f) {
+            throw new UDFArgumentException("target must be in range 0 to 1: " + target);
+        }
+    }
+
+    @Override
+    protected float computeGradient(final float target, final float predicted) {
+        float eta = etaEstimator.eta(count);
+        float gradient = LossFunctions.logisticLoss(target, predicted);
+        return eta * gradient;
     }
 
 }

--- a/core/src/main/java/hivemall/regression/PassiveAggressiveRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/PassiveAggressiveRegressionUDTF.java
@@ -18,7 +18,7 @@
  */
 package hivemall.regression;
 
-import hivemall.common.LossFunctions;
+import hivemall.optimizer.LossFunctions;
 import hivemall.common.OnlineVariance;
 import hivemall.model.FeatureValue;
 import hivemall.model.PredictionResult;

--- a/core/src/main/java/hivemall/regression/PassiveAggressiveRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/PassiveAggressiveRegressionUDTF.java
@@ -18,10 +18,10 @@
  */
 package hivemall.regression;
 
-import hivemall.optimizer.LossFunctions;
 import hivemall.common.OnlineVariance;
 import hivemall.model.FeatureValue;
 import hivemall.model.PredictionResult;
+import hivemall.optimizer.LossFunctions;
 
 import javax.annotation.Nonnull;
 

--- a/core/src/main/java/hivemall/regression/RegressionBaseUDTF.java
+++ b/core/src/main/java/hivemall/regression/RegressionBaseUDTF.java
@@ -261,7 +261,7 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
         throw new UnsupportedOperationException();
     }
 
-    protected final void accumulateUpdate(@Nonnull final FeatureValue[] features, final float coeff) {
+    protected void accumulateUpdate(@Nonnull final FeatureValue[] features, final float coeff) {
         for (int i = 0; i < features.length; i++) {
             if (features[i] == null) {
                 continue;
@@ -281,7 +281,7 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
         sampled++;
     }
 
-    protected final void batchUpdate() {
+    protected void batchUpdate() {
         if (accumulated.isEmpty()) {
             this.sampled = 0;
             return;

--- a/core/src/main/java/hivemall/regression/RegressionBaseUDTF.java
+++ b/core/src/main/java/hivemall/regression/RegressionBaseUDTF.java
@@ -25,6 +25,7 @@ import hivemall.model.PredictionModel;
 import hivemall.model.PredictionResult;
 import hivemall.model.WeightValue;
 import hivemall.model.WeightValue.WeightValueWithCovar;
+import hivemall.optimizer.Optimizer;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.lang.FloatAccumulator;
@@ -64,6 +65,7 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
     private boolean parseFeature;
 
     protected PredictionModel model;
+    protected Optimizer optimizerImpl;
     protected int count;
 
     // The accumulated delta of each weight values.
@@ -87,6 +89,7 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
         if (preloadedModelFile != null) {
             loadPredictionModel(model, preloadedModelFile, featureOutputOI);
         }
+        this.optimizerImpl = createOptimizer();
 
         this.count = 0;
         this.sampled = 0;
@@ -235,7 +238,7 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
 
     protected void update(@Nonnull final FeatureValue[] features, final float target,
             final float predicted) {
-        final float grad = computeUpdate(target, predicted);
+        final float grad = computeGradient(target, predicted);
 
         if (is_mini_batch) {
             accumulateUpdate(features, grad);
@@ -247,12 +250,9 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
         }
     }
 
-    protected float computeUpdate(float target, float predicted) {
-        throw new IllegalStateException();
-    }
-
-    protected IWeightValue getNewWeight(IWeightValue old_w, float delta) {
-        throw new IllegalStateException();
+    // Compute a gradient by using a loss function in derived classes
+    protected float computeGradient(float target, float predicted) {
+        throw new UnsupportedOperationException();
     }
 
     protected final void accumulateUpdate(@Nonnull final FeatureValue[] features, final float coeff) {

--- a/core/src/main/java/hivemall/regression/RegressionBaseUDTF.java
+++ b/core/src/main/java/hivemall/regression/RegressionBaseUDTF.java
@@ -25,7 +25,6 @@ import hivemall.model.PredictionModel;
 import hivemall.model.PredictionResult;
 import hivemall.model.WeightValue;
 import hivemall.model.WeightValue.WeightValueWithCovar;
-import hivemall.optimizer.Optimizer;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.lang.FloatAccumulator;
@@ -53,8 +52,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.io.FloatWritable;
 
 /**
- * The base class for regression algorithms. RegressionBaseUDTF provides general implementation for
- * online training and batch training.
+ * The base class for regression algorithms. RegressionBaseUDTF provides general implementation for online training and batch training.
  */
 public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
     private static final Log logger = LogFactory.getLog(RegressionBaseUDTF.class);
@@ -65,21 +63,18 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
     private boolean parseFeature;
 
     protected PredictionModel model;
-    protected Optimizer optimizerImpl;
     protected int count;
 
     // The accumulated delta of each weight values.
     protected transient Map<Object, FloatAccumulator> accumulated;
     protected int sampled;
 
-    private boolean enableNewModel;
-
     public RegressionBaseUDTF() {
-        this.enableNewModel = false;
+        this(false);
     }
 
     public RegressionBaseUDTF(boolean enableNewModel) {
-        this.enableNewModel = enableNewModel;
+        super(enableNewModel);
     }
 
     @Override
@@ -95,11 +90,10 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
 
         PrimitiveObjectInspector featureOutputOI = dense_model ? PrimitiveObjectInspectorFactory.javaIntObjectInspector
                 : featureInputOI;
-        this.model = enableNewModel? createNewModel(null) : createModel();
+        this.model = createModel();
         if (preloadedModelFile != null) {
             loadPredictionModel(model, preloadedModelFile, featureOutputOI);
         }
-        this.optimizerImpl = createOptimizer();
 
         this.count = 0;
         this.sampled = 0;
@@ -260,7 +254,9 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
         }
     }
 
-    // Compute a gradient by using a loss function in derived classes
+    /**
+     * Compute a gradient by using a loss function in derived classes
+     */
     protected float computeGradient(float target, float predicted) {
         throw new UnsupportedOperationException();
     }

--- a/core/src/main/java/hivemall/regression/RegressionBaseUDTF.java
+++ b/core/src/main/java/hivemall/regression/RegressionBaseUDTF.java
@@ -72,6 +72,16 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
     protected transient Map<Object, FloatAccumulator> accumulated;
     protected int sampled;
 
+    private boolean enableNewModel;
+
+    public RegressionBaseUDTF() {
+        this.enableNewModel = false;
+    }
+
+    public RegressionBaseUDTF(boolean enableNewModel) {
+        this.enableNewModel = enableNewModel;
+    }
+
     @Override
     public StructObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
         if (argOIs.length < 2) {
@@ -85,7 +95,7 @@ public abstract class RegressionBaseUDTF extends LearnerBaseUDTF {
 
         PrimitiveObjectInspector featureOutputOI = dense_model ? PrimitiveObjectInspectorFactory.javaIntObjectInspector
                 : featureInputOI;
-        this.model = createModel();
+        this.model = enableNewModel? createNewModel(null) : createModel();
         if (preloadedModelFile != null) {
             loadPredictionModel(model, preloadedModelFile, featureOutputOI);
         }

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -103,7 +103,7 @@ public class GeneralClassifierUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, options);
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, options);
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
 
@@ -130,8 +130,7 @@ public class GeneralClassifierUDTFTest {
             float score = udtf.predict(udtf.parseFeatures(samplesList.get(i)));
             int predicted = score > 0.f ? 1 : 0;
 
-            println("Score: " + score + ", Predicted: " + predicted + ", Actual: "
-                    + label);
+            println("Score: " + score + ", Predicted: " + predicted + ", Actual: " + label);
 
             if (predicted == label) {
                 ++numCorrect;

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -54,7 +54,7 @@ public class GeneralClassifierUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-opt UnsupportedOpt");
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-opt UnsupportedOpt");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
@@ -66,7 +66,7 @@ public class GeneralClassifierUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss UnsupportedLoss");
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss UnsupportedLoss");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
@@ -78,7 +78,7 @@ public class GeneralClassifierUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-reg UnsupportedReg");
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-reg UnsupportedReg");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
@@ -93,17 +93,18 @@ public class GeneralClassifierUDTFTest {
         samplesList.add(Arrays.asList("1:1", "2:2"));
         samplesList.add(Arrays.asList("1:2", "2:1"));
 
-        int[] labels = new int[]{0, 0, 0, 1, 1, 1};
+        int[] labels = new int[] {0, 0, 0, 1, 1, 1};
 
         int nIter = 10;
 
         String[] optimizers = new String[] {"SGD", "AdaDelta", "AdaGrad", "Adam"};
         String[] regularizations = new String[] {"NO", "L1", "L2", "ElasticNet", "RDA"};
-        String[] lossFunctions = new String[] {"HingeLoss", "LogLoss", "SquaredHingeLoss", "ModifiedHuberLoss",
-                "SquaredLoss", "QuantileLoss", "EpsilonInsensitiveLoss", "HuberLoss"};
+        String[] lossFunctions = new String[] {"HingeLoss", "LogLoss", "SquaredHingeLoss",
+                "ModifiedHuberLoss", "SquaredLoss", "QuantileLoss", "EpsilonInsensitiveLoss",
+                "HuberLoss"};
 
-        for (String opt: optimizers) {
-            for (String reg: regularizations) {
+        for (String opt : optimizers) {
+            for (String reg : regularizations) {
                 if (reg == "RDA" && opt != "AdaGrad") {
                     continue;
                 }
@@ -117,13 +118,13 @@ public class GeneralClassifierUDTFTest {
                     ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
                     ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
                     ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                            PrimitiveObjectInspectorFactory.javaStringObjectInspector, options);
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector, options);
 
-                    udtf.initialize(new ObjectInspector[]{stringListOI, intOI, params});
+                    udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
 
                     for (int it = 0; it < nIter; it++) {
                         for (int i = 0, size = samplesList.size(); i < size; i++) {
-                            udtf.process(new Object[]{samplesList.get(i), labels[i]});
+                            udtf.process(new Object[] {samplesList.get(i), labels[i]});
                         }
                     }
 
@@ -136,7 +137,8 @@ public class GeneralClassifierUDTFTest {
                         float score = udtf.predict(udtf.parseFeatures(samplesList.get(i)));
                         int predicted = score > 0.f ? 1 : 0;
 
-                        println("Score: " + score + ", Predicted: " + predicted + ", Actual: " + label);
+                        println("Score: " + score + ", Predicted: " + predicted + ", Actual: "
+                                + label);
 
                         if (predicted == label) {
                             ++numCorrect;
@@ -161,12 +163,13 @@ public class GeneralClassifierUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-opt SGD -loss logloss -reg L2 -lambda 0.1");
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+            "-opt SGD -loss logloss -reg L2 -lambda 0.1");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
 
         BufferedReader news20 = readFile("news20-small.binary.gz");
-        ArrayList<Integer> labels =  new ArrayList<Integer>();
+        ArrayList<Integer> labels = new ArrayList<Integer>();
         ArrayList<String> words = new ArrayList<String>();
         ArrayList<ArrayList<String>> wordsList = new ArrayList<ArrayList<String>>();
         String line = news20.readLine();

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.classifier;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+import java.util.zip.GZIPInputStream;
+
+import hivemall.utils.math.MathUtils;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+public class GeneralClassifierUDTFTest {
+    private static final boolean DEBUG = false;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnsupportedOptimizer() throws Exception {
+        GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-opt UnsupportedOpt");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnsupportedLossFunction() throws Exception {
+        GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss UnsupportedLoss");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
+    }
+
+    @Test(expected = UDFArgumentException.class)
+    public void testInvalidLossFunction() throws Exception {
+        GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss SquaredLoss");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnsupportedRegularization() throws Exception {
+        GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-reg UnsupportedReg");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
+    }
+
+    @Test
+    public void testSGDNews20() throws IOException, ParseException, HiveException {
+        int nIter = 10;
+
+        GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-opt SGD -loss logloss -reg L2");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
+
+        BufferedReader news20 = readFile("news20-small.binary.gz");
+        ArrayList<Integer> labels =  new ArrayList<Integer>();
+        ArrayList<String> words = new ArrayList<String>();
+        ArrayList<ArrayList<String>> wordsList = new ArrayList<ArrayList<String>>();
+        String line = news20.readLine();
+        while (line != null) {
+            StringTokenizer tokens = new StringTokenizer(line, " ");
+            int label = Integer.parseInt(tokens.nextToken());
+            while (tokens.hasMoreTokens()) {
+                words.add(tokens.nextToken());
+            }
+            Assert.assertFalse(words.isEmpty());
+            udtf.process(new Object[] {words, label});
+
+            labels.add(label);
+            wordsList.add((ArrayList) words.clone());
+
+            words.clear();
+            line = news20.readLine();
+        }
+        news20.close();
+
+        // perform SGD iterations
+        for (int it = 1; it < nIter; it++) {
+            for (int i = 0, size = wordsList.size(); i < size; i++) {
+                words = wordsList.get(i);
+                int label = labels.get(i);
+                udtf.process(new Object[] {words, label});
+            }
+        }
+
+        int numTests = 0;
+        int numCorrect = 0;
+
+        for (int i = 0, size = wordsList.size(); i < size; i++) {
+            words = wordsList.get(i);
+            int label = labels.get(i);
+
+            float score = udtf.predict(udtf.parseFeatures(words));
+            int predicted = MathUtils.sign(score);
+
+            println("Predicted: " + predicted + ", Actual: " + label);
+
+            if (predicted == label) {
+                ++numCorrect;
+            }
+            ++numTests;
+        }
+
+        float accuracy = numCorrect / (float) numTests;
+        println("Accuracy: " + accuracy);
+        Assert.assertTrue(accuracy > 0.8f);
+    }
+
+    private static void println(String msg) {
+        if (DEBUG) {
+            System.out.println(msg);
+        }
+    }
+
+    @Nonnull
+    private static BufferedReader readFile(@Nonnull String fileName) throws IOException {
+        InputStream is = GeneralClassifierUDTFTest.class.getResourceAsStream(fileName);
+        if (fileName.endsWith(".gz")) {
+            is = new GZIPInputStream(is);
+        }
+        return new BufferedReader(new InputStreamReader(is));
+    }
+}

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -107,20 +107,19 @@ public class GeneralClassifierUDTFTest {
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
 
-        float lossAvgPrev = Float.MAX_VALUE;
-        float lossAvg = 0.f;
+        float cumLossPrev = Float.MAX_VALUE;
+        float cumLoss = 0.f;
         int it = 0;
-        while ((it < maxIter) && (Math.abs(lossAvg - lossAvgPrev) > 1e-3f)) {
-            lossAvgPrev = lossAvg;
-            lossAvg = 0.f;
+        while ((it < maxIter) && (Math.abs(cumLoss - cumLossPrev) > 1e-3f)) {
+            cumLossPrev = cumLoss;
+            udtf.resetCumulativeLoss();
             for (int i = 0, size = samplesList.size(); i < size; i++) {
                 udtf.process(new Object[] {samplesList.get(i), labels[i]});
-                lossAvg += udtf.getLoss();
             }
-            lossAvg /= samplesList.size();
-            println("Iter: " + ++it + ", Avg. loss: " + lossAvg);
+            cumLoss = udtf.getCumulativeLoss();
+            println("Iter: " + ++it + ", Cumulative loss: " + cumLoss);
         }
-        Assert.assertTrue(lossAvg < 0.5f);
+        Assert.assertTrue(cumLoss / samplesList.size() < 0.5f);
 
         int numTests = 0;
         int numCorrect = 0;

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -45,7 +45,7 @@ import javax.annotation.Nonnull;
 public class GeneralClassifierUDTFTest {
     private static final boolean DEBUG = false;
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UDFArgumentException.class)
     public void testUnsupportedOptimizer() throws Exception {
         GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
         ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
@@ -57,7 +57,7 @@ public class GeneralClassifierUDTFTest {
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UDFArgumentException.class)
     public void testUnsupportedLossFunction() throws Exception {
         GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
         ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
@@ -81,7 +81,7 @@ public class GeneralClassifierUDTFTest {
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UDFArgumentException.class)
     public void testUnsupportedRegularization() throws Exception {
         GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
         ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -84,6 +84,8 @@ public class GeneralClassifierUDTFTest {
     }
 
     private void run(@Nonnull String options) throws Exception {
+        println(options);
+
         ArrayList<List<String>> samplesList = new ArrayList<List<String>>();
         samplesList.add(Arrays.asList("1:-2", "2:-1"));
         samplesList.add(Arrays.asList("1:-1", "2:-1"));
@@ -159,10 +161,14 @@ public class GeneralClassifierUDTFTest {
 
                 for (String loss : lossFunctions) {
                     String options = "-opt " + opt + " -reg " + reg + " -loss " + loss;
-                    println(options);
 
                     // sparse
                     run(options);
+
+                    if (opt != "AdaGrad") {
+                        options += " -mini_batch 2";
+                        run(options);
+                    }
 
                     // dense
                     options += " -dense";

--- a/core/src/test/java/hivemall/model/NewSpaceEfficientNewDenseModelTest.java
+++ b/core/src/test/java/hivemall/model/NewSpaceEfficientNewDenseModelTest.java
@@ -26,15 +26,15 @@ import java.util.Random;
 
 import org.junit.Test;
 
-public class SpaceEfficientDenseModelTest {
+public class NewSpaceEfficientNewDenseModelTest {
 
     @Test
     public void testGetSet() {
         final int size = 1 << 12;
 
-        final SpaceEfficientDenseModel model1 = new SpaceEfficientDenseModel(size);
+        final NewSpaceEfficientDenseModel model1 = new NewSpaceEfficientDenseModel(size);
         //model1.configureClock();
-        final DenseModel model2 = new DenseModel(size);
+        final NewDenseModel model2 = new NewDenseModel(size);
         //model2.configureClock();
 
         final Random rand = new Random();

--- a/core/src/test/java/hivemall/optimizer/OptimizerTest.java
+++ b/core/src/test/java/hivemall/optimizer/OptimizerTest.java
@@ -93,8 +93,8 @@ public final class OptimizerTest {
         // We need special handling for `Optimizer#RDA`
         options.put("optimizer", "AdaGrad");
         options.put("regularization", "RDA");
-        Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.RDA);
-        Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.RDA);
+        Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdagradRDA);
+        Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdagradRDA);
 
         // `SGD`, `AdaDelta`, and `Adam` currently does not support `RDA`
         for(final String optimizerType : new String[] {"SGD", "AdaDelta", "Adam"}) {
@@ -120,11 +120,11 @@ public final class OptimizerTest {
         try {
             for(int i = 0; i < numUpdates; i++) {
                 int index = rnd.nextInt(initSize);
-                weights[index] = optimizer.computeUpdatedValue(index, weights[index], 0.1f);
+                weights[index] = optimizer.update(index, weights[index], 0.1f);
             }
             for(int i = 0; i < numUpdates; i++) {
                 int index = rnd.nextInt(initSize * 2);
-                weights[index] = optimizer.computeUpdatedValue(index, weights[index], 0.1f);
+                weights[index] = optimizer.update(index, weights[index], 0.1f);
             }
         } catch(Exception e) {
             Assert.fail("failed to update weights: " + e.getMessage());

--- a/core/src/test/java/hivemall/optimizer/OptimizerTest.java
+++ b/core/src/test/java/hivemall/optimizer/OptimizerTest.java
@@ -66,25 +66,25 @@ public final class OptimizerTest {
         final Map<String, String> options = new HashMap<String, String>();
         final String[] regTypes = new String[] {"NO", "L1", "L2", "ElasticNet"};
         options.put("optimizer", "SGD");
-        for(final String regType : regTypes) {
+        for (final String regType : regTypes) {
             options.put("regularization", regType);
             Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
             Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
         }
         options.put("optimizer", "AdaDelta");
-        for(final String regType : regTypes) {
+        for (final String regType : regTypes) {
             options.put("regularization", regType);
             Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaDelta);
             Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaDelta);
         }
         options.put("optimizer", "AdaGrad");
-        for(final String regType : regTypes) {
+        for (final String regType : regTypes) {
             options.put("regularization", regType);
             Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaGrad);
             Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaGrad);
         }
         options.put("optimizer", "Adam");
-        for(final String regType : regTypes) {
+        for (final String regType : regTypes) {
             options.put("regularization", regType);
             Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.Adam);
             Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.Adam);
@@ -97,7 +97,7 @@ public final class OptimizerTest {
         Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdagradRDA);
 
         // `SGD`, `AdaDelta`, and `Adam` currently does not support `RDA`
-        for(final String optimizerType : new String[] {"SGD", "AdaDelta", "Adam"}) {
+        for (final String optimizerType : new String[] {"SGD", "AdaDelta", "Adam"}) {
             options.put("optimizer", optimizerType);
             try {
                 DenseOptimizerFactory.create(8, options);
@@ -118,15 +118,15 @@ public final class OptimizerTest {
         final float[] weights = new float[initSize * 2];
         final Random rnd = new Random();
         try {
-            for(int i = 0; i < numUpdates; i++) {
+            for (int i = 0; i < numUpdates; i++) {
                 int index = rnd.nextInt(initSize);
                 weights[index] = optimizer.update(index, weights[index], 0.1f);
             }
-            for(int i = 0; i < numUpdates; i++) {
+            for (int i = 0; i < numUpdates; i++) {
                 int index = rnd.nextInt(initSize * 2);
                 weights[index] = optimizer.update(index, weights[index], 0.1f);
             }
-        } catch(Exception e) {
+        } catch (Exception e) {
             Assert.fail("failed to update weights: " + e.getMessage());
         }
     }
@@ -134,7 +134,7 @@ public final class OptimizerTest {
     private void testOptimizer(final Map<String, String> options, int numUpdates, int initSize) {
         final Map<String, String> testOptions = new HashMap<String, String>(options);
         final String[] regTypes = new String[] {"NO", "L1", "L2", "RDA", "ElasticNet"};
-        for(final String regType : regTypes) {
+        for (final String regType : regTypes) {
             options.put("regularization", regType);
             testUpdateWeights(DenseOptimizerFactory.create(1024, testOptions), 65536, 1024);
             testUpdateWeights(SparseOptimizerFactory.create(1024, testOptions), 65536, 1024);

--- a/core/src/test/java/hivemall/optimizer/OptimizerTest.java
+++ b/core/src/test/java/hivemall/optimizer/OptimizerTest.java
@@ -18,12 +18,12 @@
  */
 package hivemall.optimizer;
 
+import org.junit.Assert;
+import org.junit.Test;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 public final class OptimizerTest {
 
@@ -65,29 +65,43 @@ public final class OptimizerTest {
     public void testOptimizerFactory() {
         final Map<String, String> options = new HashMap<String, String>();
         final String[] regTypes = new String[] {"NO", "L1", "L2"};
+        final String[] lossFunctions = new String[] {"SquaredLoss", "LogLoss", "HingeLoss", "SquaredHingeLoss",
+                "QuantileLoss", "EpsilonInsensitiveLoss"};
+        options.put("optimizer", "SGD");
         for(final String regType : regTypes) {
-            options.put("optimizer", "SGD");
             options.put("regularization", regType);
-            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
-            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
+            for (final String lossFunction : lossFunctions) {
+                options.put("loss_function", lossFunction);
+                Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
+                Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
+            }
         }
+        options.put("optimizer", "AdaDelta");
         for(final String regType : regTypes) {
-            options.put("optimizer", "AdaDelta");
             options.put("regularization", regType);
-            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaDelta);
-            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaDelta);
+            for (final String lossFunction : lossFunctions) {
+                options.put("loss_function", lossFunction);
+                Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaDelta);
+                Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaDelta);
+            }
         }
+        options.put("optimizer", "AdaGrad");
         for(final String regType : regTypes) {
-            options.put("optimizer", "AdaGrad");
             options.put("regularization", regType);
-            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaGrad);
-            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaGrad);
+            for (final String lossFunction : lossFunctions) {
+                options.put("loss_function", lossFunction);
+                Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaGrad);
+                Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaGrad);
+            }
         }
+        options.put("optimizer", "Adam");
         for(final String regType : regTypes) {
-            options.put("optimizer", "Adam");
             options.put("regularization", regType);
-            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.Adam);
-            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.Adam);
+            for (final String lossFunction : lossFunctions) {
+                options.put("loss_function", lossFunction);
+                Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.Adam);
+                Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.Adam);
+            }
         }
 
         // We need special handling for `Optimizer#RDA`
@@ -134,10 +148,15 @@ public final class OptimizerTest {
     private void testOptimizer(final Map<String, String> options, int numUpdates, int initSize) {
         final Map<String, String> testOptions = new HashMap<String, String>(options);
         final String[] regTypes = new String[] {"NO", "L1", "L2", "RDA"};
+        final String[] lossFunctions = new String[] {"SquaredLoss", "LogLoss", "HingeLoss", "SquaredHingeLoss",
+                "QuantileLoss", "EpsilonInsensitiveLoss"};
         for(final String regType : regTypes) {
             options.put("regularization", regType);
-            testUpdateWeights(DenseOptimizerFactory.create(1024, testOptions), 65536, 1024);
-            testUpdateWeights(SparseOptimizerFactory.create(1024, testOptions), 65536, 1024);
+            for (final String lossFunction : lossFunctions) {
+                options.put("loss_function", lossFunction);
+                testUpdateWeights(DenseOptimizerFactory.create(1024, testOptions), 65536, 1024);
+                testUpdateWeights(SparseOptimizerFactory.create(1024, testOptions), 65536, 1024);
+            }
         }
     }
 

--- a/core/src/test/java/hivemall/optimizer/OptimizerTest.java
+++ b/core/src/test/java/hivemall/optimizer/OptimizerTest.java
@@ -65,43 +65,29 @@ public final class OptimizerTest {
     public void testOptimizerFactory() {
         final Map<String, String> options = new HashMap<String, String>();
         final String[] regTypes = new String[] {"NO", "L1", "L2"};
-        final String[] lossFunctions = new String[] {"SquaredLoss", "LogLoss", "HingeLoss", "SquaredHingeLoss",
-                "QuantileLoss", "EpsilonInsensitiveLoss"};
         options.put("optimizer", "SGD");
         for(final String regType : regTypes) {
             options.put("regularization", regType);
-            for (final String lossFunction : lossFunctions) {
-                options.put("loss_function", lossFunction);
-                Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
-                Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
-            }
+            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
+            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
         }
         options.put("optimizer", "AdaDelta");
         for(final String regType : regTypes) {
             options.put("regularization", regType);
-            for (final String lossFunction : lossFunctions) {
-                options.put("loss_function", lossFunction);
-                Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaDelta);
-                Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaDelta);
-            }
+            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaDelta);
+            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaDelta);
         }
         options.put("optimizer", "AdaGrad");
         for(final String regType : regTypes) {
             options.put("regularization", regType);
-            for (final String lossFunction : lossFunctions) {
-                options.put("loss_function", lossFunction);
-                Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaGrad);
-                Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaGrad);
-            }
+            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaGrad);
+            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaGrad);
         }
         options.put("optimizer", "Adam");
         for(final String regType : regTypes) {
             options.put("regularization", regType);
-            for (final String lossFunction : lossFunctions) {
-                options.put("loss_function", lossFunction);
-                Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.Adam);
-                Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.Adam);
-            }
+            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.Adam);
+            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.Adam);
         }
 
         // We need special handling for `Optimizer#RDA`
@@ -148,15 +134,10 @@ public final class OptimizerTest {
     private void testOptimizer(final Map<String, String> options, int numUpdates, int initSize) {
         final Map<String, String> testOptions = new HashMap<String, String>(options);
         final String[] regTypes = new String[] {"NO", "L1", "L2", "RDA"};
-        final String[] lossFunctions = new String[] {"SquaredLoss", "LogLoss", "HingeLoss", "SquaredHingeLoss",
-                "QuantileLoss", "EpsilonInsensitiveLoss"};
         for(final String regType : regTypes) {
             options.put("regularization", regType);
-            for (final String lossFunction : lossFunctions) {
-                options.put("loss_function", lossFunction);
-                testUpdateWeights(DenseOptimizerFactory.create(1024, testOptions), 65536, 1024);
-                testUpdateWeights(SparseOptimizerFactory.create(1024, testOptions), 65536, 1024);
-            }
+            testUpdateWeights(DenseOptimizerFactory.create(1024, testOptions), 65536, 1024);
+            testUpdateWeights(SparseOptimizerFactory.create(1024, testOptions), 65536, 1024);
         }
     }
 

--- a/core/src/test/java/hivemall/optimizer/OptimizerTest.java
+++ b/core/src/test/java/hivemall/optimizer/OptimizerTest.java
@@ -64,7 +64,7 @@ public final class OptimizerTest {
     @Test
     public void testOptimizerFactory() {
         final Map<String, String> options = new HashMap<String, String>();
-        final String[] regTypes = new String[] {"NO", "L1", "L2"};
+        final String[] regTypes = new String[] {"NO", "L1", "L2", "ElasticNet"};
         options.put("optimizer", "SGD");
         for(final String regType : regTypes) {
             options.put("regularization", regType);
@@ -133,7 +133,7 @@ public final class OptimizerTest {
 
     private void testOptimizer(final Map<String, String> options, int numUpdates, int initSize) {
         final Map<String, String> testOptions = new HashMap<String, String>(options);
-        final String[] regTypes = new String[] {"NO", "L1", "L2", "RDA"};
+        final String[] regTypes = new String[] {"NO", "L1", "L2", "RDA", "ElasticNet"};
         for(final String regType : regTypes) {
             options.put("regularization", regType);
             testUpdateWeights(DenseOptimizerFactory.create(1024, testOptions), 65536, 1024);

--- a/core/src/test/java/hivemall/optimizer/OptimizerTest.java
+++ b/core/src/test/java/hivemall/optimizer/OptimizerTest.java
@@ -1,0 +1,172 @@
+/*
+ * Hivemall: Hive scalable Machine Learning Library
+ *
+ * Copyright (C) 2015 Makoto YUI
+ * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package hivemall.optimizer;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public final class OptimizerTest {
+
+    @Test
+    public void testIllegalOptimizer() {
+        try {
+            final Map<String, String> emptyOptions = new HashMap<String, String>();
+            DenseOptimizerFactory.create(1024, emptyOptions);
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+            // tests passed
+        }
+        try {
+            final Map<String, String> options = new HashMap<String, String>();
+            options.put("optimizer", "illegal");
+            DenseOptimizerFactory.create(1024, options);
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+            // tests passed
+        }
+        try {
+            final Map<String, String> emptyOptions = new HashMap<String, String>();
+            SparseOptimizerFactory.create(1024, emptyOptions);
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+            // tests passed
+        }
+        try {
+            final Map<String, String> options = new HashMap<String, String>();
+            options.put("optimizer", "illegal");
+            SparseOptimizerFactory.create(1024, options);
+            Assert.fail();
+        } catch (IllegalArgumentException e) {
+            // tests passed
+        }
+    }
+
+    @Test
+    public void testOptimizerFactory() {
+        final Map<String, String> options = new HashMap<String, String>();
+        final String[] regTypes = new String[] {"NO", "L1", "L2"};
+        for(final String regType : regTypes) {
+            options.put("optimizer", "SGD");
+            options.put("regularization", regType);
+            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
+            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof Optimizer.SGD);
+        }
+        for(final String regType : regTypes) {
+            options.put("optimizer", "AdaDelta");
+            options.put("regularization", regType);
+            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaDelta);
+            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaDelta);
+        }
+        for(final String regType : regTypes) {
+            options.put("optimizer", "AdaGrad");
+            options.put("regularization", regType);
+            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.AdaGrad);
+            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.AdaGrad);
+        }
+        for(final String regType : regTypes) {
+            options.put("optimizer", "Adam");
+            options.put("regularization", regType);
+            Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.Adam);
+            Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.Adam);
+        }
+
+        // We need special handling for `Optimizer#RDA`
+        options.put("optimizer", "AdaGrad");
+        options.put("regularization", "RDA");
+        Assert.assertTrue(DenseOptimizerFactory.create(8, options) instanceof DenseOptimizerFactory.RDA);
+        Assert.assertTrue(SparseOptimizerFactory.create(8, options) instanceof SparseOptimizerFactory.RDA);
+
+        // `SGD`, `AdaDelta`, and `Adam` currently does not support `RDA`
+        for(final String optimizerType : new String[] {"SGD", "AdaDelta", "Adam"}) {
+            options.put("optimizer", optimizerType);
+            try {
+                DenseOptimizerFactory.create(8, options);
+                Assert.fail();
+            } catch (IllegalArgumentException e) {
+                // tests passed
+            }
+            try {
+                SparseOptimizerFactory.create(8, options);
+                Assert.fail();
+            } catch (IllegalArgumentException e) {
+                // tests passed
+            }
+        }
+    }
+
+    private void testUpdateWeights(Optimizer optimizer, int numUpdates, int initSize) {
+        final float[] weights = new float[initSize * 2];
+        final Random rnd = new Random();
+        try {
+            for(int i = 0; i < numUpdates; i++) {
+                int index = rnd.nextInt(initSize);
+                weights[index] = optimizer.computeUpdatedValue(index, weights[index], 0.1f);
+            }
+            for(int i = 0; i < numUpdates; i++) {
+                int index = rnd.nextInt(initSize * 2);
+                weights[index] = optimizer.computeUpdatedValue(index, weights[index], 0.1f);
+            }
+        } catch(Exception e) {
+            Assert.fail("failed to update weights: " + e.getMessage());
+        }
+    }
+
+    private void testOptimizer(final Map<String, String> options, int numUpdates, int initSize) {
+        final Map<String, String> testOptions = new HashMap<String, String>(options);
+        final String[] regTypes = new String[] {"NO", "L1", "L2", "RDA"};
+        for(final String regType : regTypes) {
+            options.put("regularization", regType);
+            testUpdateWeights(DenseOptimizerFactory.create(1024, testOptions), 65536, 1024);
+            testUpdateWeights(SparseOptimizerFactory.create(1024, testOptions), 65536, 1024);
+        }
+    }
+
+    @Test
+    public void testSGDOptimizer() {
+        final Map<String, String> options = new HashMap<String, String>();
+        options.put("optimizer", "SGD");
+        testOptimizer(options, 65536, 1024);
+    }
+
+    @Test
+    public void testAdaDeltaOptimizer() {
+        final Map<String, String> options = new HashMap<String, String>();
+        options.put("optimizer", "AdaDelta");
+        testOptimizer(options, 65536, 1024);
+    }
+
+    @Test
+    public void testAdaGradOptimizer() {
+        final Map<String, String> options = new HashMap<String, String>();
+        options.put("optimizer", "AdaGrad");
+        testOptimizer(options, 65536, 1024);
+    }
+
+    @Test
+    public void testAdamOptimizer() {
+        final Map<String, String> options = new HashMap<String, String>();
+        options.put("optimizer", "Adam");
+        testOptimizer(options, 65536, 1024);
+    }
+
+}

--- a/core/src/test/java/hivemall/optimizer/OptimizerTest.java
+++ b/core/src/test/java/hivemall/optimizer/OptimizerTest.java
@@ -1,20 +1,20 @@
 /*
- * Hivemall: Hive scalable Machine Learning Library
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * Copyright (C) 2015 Makoto YUI
- * Copyright (C) 2013-2015 National Institute of Advanced Industrial Science and Technology (AIST)
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package hivemall.optimizer;
 

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -114,7 +114,7 @@ public class GeneralRegressionUDTFTest {
         String line = news20.readLine();
         while (line != null) {
             StringTokenizer tokens = new StringTokenizer(line, " ");
-            float y = Float.parseFloat(tokens.nextToken()) / 5.f;
+            float y = Float.parseFloat(tokens.nextToken());
             while (tokens.hasMoreTokens()) {
                 features.add(tokens.nextToken());
             }

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -121,20 +121,19 @@ public class GeneralRegressionUDTFTest {
 
         udtf.initialize(new ObjectInspector[] {stringListOI, floatOI, params});
 
-        float lossAvgPrev = Float.MAX_VALUE;
-        float lossAvg = 0.f;
+        float cumLossPrev = Float.MAX_VALUE;
+        float cumLoss = 0.f;
         int it = 0;
-        while ((it < maxIter) && (Math.abs(lossAvg - lossAvgPrev) > 1e-6f)) {
-            lossAvgPrev = lossAvg;
-            lossAvg = 0.f;
+        while ((it < maxIter) && (Math.abs(cumLoss - cumLossPrev) > 1e-3f)) {
+            cumLossPrev = cumLoss;
+            udtf.resetCumulativeLoss();
             for (int i = 0; i < numTrain; i++) {
                 udtf.process(new Object[] {samplesList.get(i), (Float) ys.get(i)});
-                lossAvg += udtf.getLoss();
             }
-            lossAvg /= numTrain;
-            println("Iter: " + ++it + ", Avg. loss: " + lossAvg);
+            cumLoss = udtf.getCumulativeLoss();
+            println("Iter: " + ++it + ", Cumulative loss: " + cumLoss);
         }
-        Assert.assertTrue(lossAvg < 0.1f);
+        Assert.assertTrue(cumLoss / numTrain < 0.1f);
 
         float accum = 0.f;
 

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -54,7 +54,7 @@ public class GeneralRegressionUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-opt UnsupportedOpt");
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-opt UnsupportedOpt");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
@@ -66,7 +66,7 @@ public class GeneralRegressionUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss UnsupportedLoss");
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss UnsupportedLoss");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
@@ -78,7 +78,7 @@ public class GeneralRegressionUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss HingeLoss");
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss HingeLoss");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
@@ -90,7 +90,7 @@ public class GeneralRegressionUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-reg UnsupportedReg");
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-reg UnsupportedReg");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
@@ -109,16 +109,17 @@ public class GeneralRegressionUDTFTest {
         samplesList.add(Arrays.asList("1:2", "2:2"));
         samplesList.add(Arrays.asList("1:3", "2:2"));
 
-        int[] ys = new int[]{1, 1, 1, 2, 2, 2, 1, 2, 2};
+        int[] ys = new int[] {1, 1, 1, 2, 2, 2, 1, 2, 2};
 
         int nIter = 20;
 
         String[] optimizers = new String[] {"SGD", "AdaDelta", "AdaGrad", "Adam"};
         String[] regularizations = new String[] {"NO", "L1", "L2", "ElasticNet", "RDA"};
-        String[] lossFunctions = new String[] {"SquaredLoss", "QuantileLoss", "EpsilonInsensitiveLoss", "HuberLoss"};
+        String[] lossFunctions = new String[] {"SquaredLoss", "QuantileLoss",
+                "EpsilonInsensitiveLoss", "HuberLoss"};
 
-        for (String opt: optimizers) {
-            for (String reg: regularizations) {
+        for (String opt : optimizers) {
+            for (String reg : regularizations) {
                 if (reg == "RDA" && opt != "AdaGrad") {
                     continue;
                 }
@@ -133,13 +134,13 @@ public class GeneralRegressionUDTFTest {
                     ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
                     ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
                     ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                            PrimitiveObjectInspectorFactory.javaStringObjectInspector, options);
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector, options);
 
-                    udtf.initialize(new ObjectInspector[]{stringListOI, intOI, params});
+                    udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
 
                     for (int it = 0; it < nIter; it++) {
                         for (int i = 0; i < 6; i++) {
-                            udtf.process(new Object[]{samplesList.get(i), ys[i]});
+                            udtf.process(new Object[] {samplesList.get(i), ys[i]});
                         }
                     }
 
@@ -171,15 +172,15 @@ public class GeneralRegressionUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector,
-                "-opt SGD -loss squaredloss -reg ElasticNet -lambda 1e-3 -eta fixed -eta0 1e-3");
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+            "-opt SGD -loss squaredloss -reg ElasticNet -lambda 1e-3 -eta fixed -eta0 1e-3");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, floatOI, params});
 
         BufferedReader news20 = readFile("5107786.txt.gz");
         ArrayList<String> features = new ArrayList<String>();
         ArrayList<ArrayList<String>> featuresList = new ArrayList<ArrayList<String>>();
-        ArrayList<Float> ys =  new ArrayList<Float>();
+        ArrayList<Float> ys = new ArrayList<Float>();
         String line = news20.readLine();
         while (line != null) {
             StringTokenizer tokens = new StringTokenizer(line, " ");

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.regression;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.StringTokenizer;
+import java.util.zip.GZIPInputStream;
+
+import hivemall.fm.FactorizationMachineUDTFTest;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.annotation.Nonnull;
+
+public class GeneralRegressionUDTFTest {
+    private static final boolean DEBUG = false;
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnsupportedOptimizer() throws Exception {
+        GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-opt UnsupportedOpt");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnsupportedLossFunction() throws Exception {
+        GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss UnsupportedLoss");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
+    }
+
+    @Test(expected = UDFArgumentException.class)
+    public void testInvalidLossFunction() throws Exception {
+        GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-loss HingeLoss");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testUnsupportedRegularization() throws Exception {
+        GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-reg UnsupportedReg");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
+    }
+
+    @Test
+    public void testSGD() throws IOException, ParseException, HiveException {
+        int nIter = 10;
+
+        GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
+        ObjectInspector floatOI = PrimitiveObjectInspectorFactory.javaFloatObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                "-opt SGD -loss squaredloss -reg L2 -lambda 1e-3 -eta fixed -eta0 1e-6");
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, floatOI, params});
+
+        BufferedReader news20 = readFile("5107786.txt.gz");
+        ArrayList<String> features = new ArrayList<String>();
+        ArrayList<ArrayList<String>> featuresList = new ArrayList<ArrayList<String>>();
+        ArrayList<Float> ys =  new ArrayList<Float>();
+        String line = news20.readLine();
+        while (line != null) {
+            StringTokenizer tokens = new StringTokenizer(line, " ");
+            float y = Float.parseFloat(tokens.nextToken()) / 5.f;
+            while (tokens.hasMoreTokens()) {
+                features.add(tokens.nextToken());
+            }
+            Assert.assertFalse(features.isEmpty());
+            udtf.process(new Object[] {features, y});
+
+            ys.add(y);
+            featuresList.add((ArrayList) features.clone());
+
+            features.clear();
+            line = news20.readLine();
+        }
+        news20.close();
+
+        // perform SGD iterations
+        for (int it = 1; it < nIter; it++) {
+            for (int i = 0, size = featuresList.size(); i < size; i++) {
+                features = featuresList.get(i);
+                float y = ys.get(i);
+                udtf.process(new Object[] {features, y});
+            }
+        }
+
+        float accum = 0.f;
+
+        for (int i = 0, size = featuresList.size(); i < size; i++) {
+            features = featuresList.get(i);
+            float y = ys.get(i);
+
+            float predicted = udtf.predict(udtf.parseFeatures(features));
+            println("Predicted: " + predicted + ", Actual: " + y);
+
+            accum += Math.abs(y - predicted);
+        }
+
+        float err = accum / ys.size();
+        println("Mean absolute error: " + err);
+        Assert.assertTrue(err < 2.5f);
+    }
+
+    @Nonnull
+    private static BufferedReader readFile(@Nonnull String fileName) throws IOException {
+        // use testing resource of FMs
+        InputStream is = FactorizationMachineUDTFTest.class.getResourceAsStream(fileName);
+        if (fileName.endsWith(".gz")) {
+            is = new GZIPInputStream(is);
+        }
+        return new BufferedReader(new InputStreamReader(is));
+    }
+
+    private static void println(String msg) {
+        if (DEBUG) {
+            System.out.println(msg);
+        }
+    }
+}

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -117,7 +117,7 @@ public class GeneralRegressionUDTFTest {
         ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
-                PrimitiveObjectInspectorFactory.javaStringObjectInspector, options);
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, options);
 
         udtf.initialize(new ObjectInspector[] {stringListOI, floatOI, params});
 

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -86,6 +86,8 @@ public class GeneralRegressionUDTFTest {
     }
 
     private void run(@Nonnull String options) throws Exception {
+        println(options);
+
         int numSamples = 100;
 
         float x1Min = -5.f, x1Max = 5.f;
@@ -108,7 +110,7 @@ public class GeneralRegressionUDTFTest {
         }
 
         int numTrain = (int) (numSamples * 0.8);
-        int maxIter = 256;
+        int maxIter = 512;
 
         GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
         ObjectInspector floatOI = PrimitiveObjectInspectorFactory.javaFloatObjectInspector;
@@ -122,7 +124,7 @@ public class GeneralRegressionUDTFTest {
         float lossAvgPrev = Float.MAX_VALUE;
         float lossAvg = 0.f;
         int it = 0;
-        while ((it < maxIter) && (Math.abs(lossAvg - lossAvgPrev) > 1e-3f)) {
+        while ((it < maxIter) && (Math.abs(lossAvg - lossAvgPrev) > 1e-6f)) {
             lossAvgPrev = lossAvg;
             lossAvg = 0.f;
             for (int i = 0; i < numTrain; i++) {
@@ -166,10 +168,15 @@ public class GeneralRegressionUDTFTest {
                 for (String loss : lossFunctions) {
                     String options = "-opt " + opt + " -reg " + reg + " -loss " + loss
                             + " -lambda 1e-6 -eta0 1e-1";
-                    println(options);
 
                     // sparse
                     run(options);
+
+                    // mini-batch
+                    if (opt != "AdaGrad") {
+                        options += " -mini_batch 10";
+                        run(options);
+                    }
 
                     // dense
                     options += " -dense";

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -45,7 +45,7 @@ import javax.annotation.Nonnull;
 public class GeneralRegressionUDTFTest {
     private static final boolean DEBUG = false;
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UDFArgumentException.class)
     public void testUnsupportedOptimizer() throws Exception {
         GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
         ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
@@ -57,7 +57,7 @@ public class GeneralRegressionUDTFTest {
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UDFArgumentException.class)
     public void testUnsupportedLossFunction() throws Exception {
         GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
         ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
@@ -81,7 +81,7 @@ public class GeneralRegressionUDTFTest {
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UDFArgumentException.class)
     public void testUnsupportedRegularization() throws Exception {
         GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
         ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -71,37 +71,44 @@
 
 * [Data Generation](eval/datagen.md)
     * [Logistic Regression data generation](eval/lr_datagen.md)
+    
+## Part V - Prediction
 
-## Part V - Binary classification
+* [How Prediction Works](misc/prediction.md)
+* [Regression](regression/general.md)
+* [Binary Classification](binaryclass/general.md)
+    
+## Part VI - Binary classification tutorials
 
-* [a9a Tutorial](binaryclass/a9a.md)
+* [a9a](binaryclass/a9a.md)
     * [Data preparation](binaryclass/a9a_dataset.md)
     * [Logistic Regression](binaryclass/a9a_lr.md)
     * [Mini-batch Gradient Descent](binaryclass/a9a_minibatch.md)
 
-* [News20 Tutorial](binaryclass/news20.md)
+* [News20](binaryclass/news20.md)
     * [Data preparation](binaryclass/news20_dataset.md)
     * [Perceptron, Passive Aggressive](binaryclass/news20_pa.md)
     * [CW, AROW, SCW](binaryclass/news20_scw.md)
     * [AdaGradRDA, AdaGrad, AdaDelta](binaryclass/news20_adagrad.md)
 
-* [KDD2010a Tutorial](binaryclass/kdd2010a.md)
+* [KDD2010a](binaryclass/kdd2010a.md)
     * [Data preparation](binaryclass/kdd2010a_dataset.md)
     * [PA, CW, AROW, SCW](binaryclass/kdd2010a_scw.md)
 
-* [KDD2010b Tutorial](binaryclass/kdd2010b.md)
+* [KDD2010b](binaryclass/kdd2010b.md)
     * [Data preparation](binaryclass/kdd2010b_dataset.md)
     * [AROW](binaryclass/kdd2010b_arow.md)
 
-* [Webspam Tutorial](binaryclass/webspam.md)
+* [Webspam](binaryclass/webspam.md)
     * [Data pareparation](binaryclass/webspam_dataset.md)
     * [PA1, AROW, SCW](binaryclass/webspam_scw.md)
 
-* [Kaggle Titanic Tutorial](binaryclass/titanic_rf.md)
+* [Kaggle Titanic](binaryclass/titanic_rf.md)
 
-## Part VI - Multiclass classification
 
-* [News20 Multiclass Tutorial](multiclass/news20.md)
+## Part VII - Multiclass classification tutorials
+
+* [News20 Multiclass](multiclass/news20.md)
     * [Data preparation](multiclass/news20_dataset.md)
     * [Data preparation for one-vs-the-rest classifiers](multiclass/news20_one-vs-the-rest_dataset.md)
     * [PA](multiclass/news20_pa.md)
@@ -109,24 +116,24 @@
     * [Ensemble learning](multiclass/news20_ensemble.md)
     * [one-vs-the-rest classifier](multiclass/news20_one-vs-the-rest.md)
 
-* [Iris Tutorial](multiclass/iris.md)
+* [Iris](multiclass/iris.md)
     * [Data preparation](multiclass/iris_dataset.md)
     * [SCW](multiclass/iris_scw.md)
     * [RandomForest](multiclass/iris_randomforest.md)
 
-## Part VII - Regression
+## Part VIII - Regression tutorials
 
-* [E2006-tfidf regression Tutorial](regression/e2006.md)
+* [E2006-tfidf regression](regression/e2006.md)
     * [Data preparation](regression/e2006_dataset.md)
     * [Passive Aggressive, AROW](regression/e2006_arow.md)
 
-* [KDDCup 2012 track 2 CTR prediction Tutorial](regression/kddcup12tr2.md)
+* [KDDCup 2012 track 2 CTR prediction](regression/kddcup12tr2.md)
     * [Data preparation](regression/kddcup12tr2_dataset.md)
     * [Logistic Regression, Passive Aggressive](regression/kddcup12tr2_lr.md)
     * [Logistic Regression with Amplifier](regression/kddcup12tr2_lr_amplify.md)
     * [AdaGrad, AdaDelta](regression/kddcup12tr2_adagrad.md)
 
-## Part VIII - Recommendation
+## Part IX - Recommendation
 
 * [Collaborative Filtering](recommend/cf.md)
     * [Item-based Collaborative Filtering](recommend/item_based_cf.md)
@@ -143,22 +150,22 @@
     * [Factorization Machine](recommend/movielens_fm.md)
     * [10-fold Cross Validation (Matrix Factorization)](recommend/movielens_cv.md)
 
-## Part IX - Anomaly Detection
+## Part X - Anomaly Detection
 
 * [Outlier Detection using Local Outlier Factor (LOF)](anomaly/lof.md)
 * [Change-Point Detection using Singular Spectrum Transformation (SST)](anomaly/sst.md)
 * [ChangeFinder: Detecting Outlier and Change-Point Simultaneously](anomaly/changefinder.md)
 
-## Part X - Clustering
+## Part XI - Clustering
 
 * [Latent Dirichlet Allocation](clustering/lda.md)
 * [Probabilistic Latent Semantic Analysis](clustering/plsa.md)
 
-## Part XI - GeoSpatial functions
+## Part XII - GeoSpatial functions
 
 * [Lat/Lon functions](geospatial/latlon.md)
 
-## Part XII - Hivemall on Spark
+## Part XIII - Hivemall on Spark
 
 * [Getting Started](spark/getting_started/README.md)
     * [Installation](spark/getting_started/installation.md)
@@ -173,7 +180,7 @@
     * [Top-k Join processing](spark/misc/topk_join.md)
     * [Other utility functions](spark/misc/functions.md)
 
-## Part XIII - Hivemall on Docker
+## Part XIV - Hivemall on Docker
 
 * [Getting Started](docker/getting_started.md)
 

--- a/docs/gitbook/binaryclass/general.md
+++ b/docs/gitbook/binaryclass/general.md
@@ -1,0 +1,132 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+Hivemall has a generic function for classification: `train_classifier`. Compared to the other functions we will see in the later chapters, `train_classifier` provides simpler and configureable generic interface which can be utilized to build binary classification models in a variety of settings.
+
+Here, we briefly introduce usage of the function. Before trying sample queries, you first need to prepare [a9a data](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/binary.html#a9a). See [our a9a tutorial page](a9a_dataset.md) for further instructions.
+
+<!-- toc -->
+
+> #### Note
+> This feature is supported from Hivemall v0.5-rc.1 or later.
+
+# Preparation
+
+- Set `total_steps` ideally be `count(1) / {# of map tasks}`:
+	```
+	hive> select count(1) from a9a_train; 
+	hive> set hivevar:total_steps=32561;
+	```
+- Set `n_samples` to compute accuracy of prediction:
+	```
+	hive> select count(1) from a9a_test;
+	hive> set hivevar:n_samples=16281;
+	```
+
+# Training
+
+```sql
+create table classification_model as
+select
+ feature,
+ avg(weight) as weight
+from
+ (
+  select
+    train_classifier(add_bias(features), label, '-loss logloss -opt SGD -reg no -eta simple -total_steps ${total_steps}') as (feature, weight)
+  from
+     a9a_train
+ ) t
+group by feature;
+```
+
+# Prediction & evaluation
+
+```sql
+WITH test_exploded as (
+  select
+    rowid,
+    label,
+    extract_feature(feature) as feature,
+    extract_weight(feature) as value
+  from
+    a9a_test LATERAL VIEW explode(add_bias(features)) t AS feature
+),
+predict as (
+  select
+    t.rowid,
+    sigmoid(sum(m.weight * t.value)) as prob,
+    CAST((case when sigmoid(sum(m.weight * t.value)) >= 0.5 then 1.0 else 0.0 end) as FLOAT) as label
+  from
+    test_exploded t LEFT OUTER JOIN
+    classification_model m ON (t.feature = m.feature)
+  group by
+    t.rowid
+),
+submit as (
+  select
+    t.label as actual,
+    pd.label as predicted,
+    pd.prob as probability
+  from
+    a9a_test t JOIN predict pd
+      on (t.rowid = pd.rowid)
+)
+select count(1) / ${n_samples} from submit
+where actual = predicted;
+```
+
+# Comparison with the other binary classifiers
+
+In the next part of this user guide, our binary classification tutorials introduce many different functions:
+
+- [Logistic Regression](a9a_lr.md)
+	- and [its mini-batch variant](a9a_minibatch.md)
+- [Perceptron](news20_pa.md#perceptron)
+- [Passive Aggressive](news20_pa.md#passive-aggressive)
+- [CW](news20_scw.md#confidence-weighted-cw)
+- [AROW](news20_scw.md#adaptive-regularization-of-weight-vectors-arow)
+- [SCW](news20_scw.md#soft-confidence-weighted-scw1)
+- [AdaGradRDA](news20_adagrad.md#adagradrda)
+- [AdaGrad](news20_adagrad.md#adagrad)
+- [AdaDelta](news20_adagrad.md#adadelta)
+
+All of them actually have the same interface, but mathematical formulation and its implementation differ from each other.
+
+In particular, the above sample queries are almost same as [a9a tutorial using Logistic Regression](a9a_lr.md). The difference is only in a choice of training function: `logress()` vs. `train_classifier()`.
+
+However, at the same time, the options `-loss logloss -opt SGD -reg no -eta simple -total_steps ${total_steps}` for `train_classifier` indicates that Hivemall uses the generic classifier as Logistic Regressor (`logress`). Hence, the accuracy of prediction based on either `logress` and `train_classifier` should be same under the configuration.
+
+In addition, `train_classifier` supports the `-mini_batch` option in a similar manner to [what `logress` does](a9a_minibatch.md). Thus, following two training queries show the same results:
+
+```sql
+select
+	logress(add_bias(features), label, '-total_steps ${total_steps} -mini_batch 10') as (feature, weight)
+from
+	a9a_train
+```
+
+```sql
+select
+	train_classifier(add_bias(features), label, '-loss logloss -opt SGD -reg no -eta simple -total_steps ${total_steps} -mini_batch 10') as (feature, weight)
+from
+	a9a_train
+```
+
+Likewise, you can generate many different classifiers based on its options.

--- a/docs/gitbook/misc/prediction.md
+++ b/docs/gitbook/misc/prediction.md
@@ -1,0 +1,137 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+<!-- toc -->
+
+# What is "prediction problem"?
+
+In a context of machine learning, numerous tasks can be seen as **prediction problem**. For example, this user guide provides solutions for:
+
+- [spam detection](../binaryclass/webspam.md)
+- [news article classification](../multiclass/news20.md)
+- [click-through-rate estimation](../regression/kddcup12tr2.md)
+
+For any kinds of prediction problems, we generally provide a set of input-output pairs as:
+
+- **Input:** Set of features
+	- e.g., `["1:0.001","4:0.23","35:0.0035",...]`
+- **Output:** Target value
+	- e.g., 1, 0, 0.54, 42.195, ...
+	
+Once a prediction model has been constructed based on the samples, the model can make prediction for unforeseen inputs. 
+
+In order to train prediction models, an algorithm so-called ***stochastic gradient descent*** (SGD) is normally applied. You can learn more about this from the following external resources:
+
+- [scikit-learn documentation](http://scikit-learn.org/stable/modules/sgd.html)
+- [Spark MLlib documentation](http://spark.apache.org/docs/latest/mllib-optimization.html)
+
+Importantly, depending on types of output value, prediction problem can be categorized into **regression** and **classification** problem.
+
+# Regression
+
+The goal of regression is to predict **real values** as shown below:
+
+| features (input) | target real value (output) |
+|:---|:---:|
+|["1:0.001","4:0.23","35:0.0035",...] | 21.3 |
+|["1:0.2","3:0.1","13:0.005",...] | 6.2 |
+|["5:1.3","22:0.0.089","77:0.0001",...] | 17.1 |
+| ... | ... |
+
+In practice, target values could be any of small/large float/int negative/positive values. [Our CTR prediction tutorial](../regression/kddcup12tr2.md) solves regression problem with small floating point target values in a 0-1 range, for example.
+
+While there are several ways to realize regression by using Hivemall, `train_regression()` is one of the most flexible functions. This feature is explained in: [Regression](../regression/general.md).
+
+# Classification
+
+In contrast to regression, output for classification problems should be (integer) **labels**:
+
+| features (input) | label (output) |
+|:---|:---:|
+|["1:0.001","4:0.23","35:0.0035",...] | 0 |
+|["1:0.2","3:0.1","13:0.005",...] | 1 |
+|["5:1.3","22:0.0.089","77:0.0001",...] | 1 |
+| ... | ... |
+
+In case the number of possible labels is 2 (0/1 or -1/1), the problem is **binary classification**, and Hivemall's `train_classifier()` function enables you to build binary classifiers. [Binary Classification](../binaryclass/general.md) demonstrates how to use the function.
+
+Another type of classification problems is **multi-class classification**. This task assumes that the number of possible labels is more than 2. We need to use different functions for the multi-class problems, and our [news20](../multiclass/news20.md) and [iris](../multiclass/iris.md) tutorials would be helpful.
+
+# Mathematical formulation of generic prediction model
+
+Here, we briefly explain about how prediction model is constructed.
+
+First and foremost, we represent **input** and **output** for prediction models as follows:
+
+- **Input:** a vector $$\mathbf{x}$$
+- **Output:** a value $$y$$
+
+For a set of samples $$(\mathbf{x}_1, y_1), (\mathbf{x}_2, y_2), \cdots, (\mathbf{x}_n, y_n)$$, the goal of prediction algorithms is to find a weight vector (i.e., parameters) $$\mathbf{w}$$ by minimizing the following error:
+
+$$
+E(\mathbf{w}) := \frac{1}{n} \sum_{i=1}^{n} L(\mathbf{w}; \mathbf{x}_i, y_i) + \lambda R(\mathbf{w})
+$$
+
+In the above formulation, there are two auxiliary functions we have to know: 
+
+- $$L(\mathbf{w}; \mathbf{x}_i, y_i)$$
+	- **Loss function** for a single sample $$(\mathbf{x}_i, y_i)$$ and given $$\mathbf{w}$$.
+	- If this function produces small values, it means the parameter $$\mathbf{w}$$ is successfully learnt. 
+- $$R(\mathbf{w})$$
+	- **Regularization function** for the current parameter $$\mathbf{w}$$.
+	- It prevents failing to a negative condition so-called **over-fitting**.
+	
+($$\lambda$$ is a small value which controls the effect of regularization function.)
+
+Eventually, minimizing the function $$E(\mathbf{w})$$ can be implemented by the SGD technique as described before, and $$\mathbf{w}$$ itself is used as a "model" for future prediction.
+
+Interestingly, depending on a choice of loss and regularization function, prediction model you obtained will behave differently; even if one combination could work as a classifier, another choice might be appropriate for regression.
+
+Below we list possible options for `train_regression` and `train_classifier`, and this is the reason why these two functions are the most flexible in Hivemall:
+
+- Loss function: `-loss`, `-loss_function`
+	- For `train_regression`
+		- SquaredLoss
+		- QuantileLoss
+		- EpsilonInsensitiveLoss
+		- HuberLoss
+	- For `train_classifier`
+		- HingeLoss
+		- LogLoss
+		- SquaredHingeLoss
+		- ModifiedHuberLoss
+		- SquaredLoss
+		- QuantileLoss
+		- EpsilonInsensitiveLoss
+		- HuberLoss
+- Regularization function: `-reg`, `-regularization`
+	- L1
+	- L2
+	- ElasticNet
+	- RDA
+	
+Additionally, there are several variants of the SGD technique, and it is also configureable as:
+
+- Optimizer `-opt`, `-optimizer`
+	- SGD
+	- AdaGrad
+	- AdaDelta
+	- Adam
+	
+In practice, you can try different combinations of the options in order to achieve higher prediction accuracy.

--- a/docs/gitbook/regression/general.md
+++ b/docs/gitbook/regression/general.md
@@ -1,0 +1,74 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+In our regression tutorials, you can tackle realistic prediction problems by using several Hivemall's regression features such as:
+
+- [PA1a](e2006_arow.html#pa1a)
+- [PA2a](e2006_arow.html#pa2a)
+- [AROW](e2006_arow.html#arow)
+- [AROWe](e2006_arow.html#arowe)
+
+Our `train_regression` function enables you to solve the regression problems with flexible configureable options. Let us try the function below.
+
+It should be noted that the sample queries require you to prepare [E2006-tfidf data](http://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/regression.html#E2006-tfidf). See [our E2006-tfidf tutorial page](../regression/e2006_dataset.md) for further instructions.
+
+<!-- toc -->
+
+> #### Note
+> This feature is supported from Hivemall v0.5-rc.1 or later.
+
+# Training
+
+```sql
+create table e2006tfidf_regression_model as
+select 
+	feature,
+	avg(weight) as weight
+from (
+	select 
+  	train_regression(features,target,'-loss squaredloss -opt AdaGrad -reg no') as (feature,weight)
+  from 
+    e2006tfidf_train_x3
+) t 
+group by feature;
+```
+
+# Prediction & evaluation
+
+```sql
+WITH predict as (
+	select
+	  t.rowid, 
+	  sum(m.weight * t.value) as predicted
+	from 
+	  e2006tfidf_test_exploded t LEFT OUTER JOIN
+	  e2006tfidf_regression_model m ON (t.feature = m.feature)
+	group by
+	  t.rowid
+),
+submit as (
+	select 
+	  t.target as actual, 
+	  p.predicted as predicted
+	from 
+	  e2006tfidf_test t JOIN predict p 
+	    on (t.rowid = p.rowid)
+)
+select rmse(predicted, actual) from submit;
+```

--- a/mixserv/src/test/java/hivemall/mix/server/MixServerTest.java
+++ b/mixserv/src/test/java/hivemall/mix/server/MixServerTest.java
@@ -18,9 +18,9 @@
  */
 package hivemall.mix.server;
 
-import hivemall.model.DenseModel;
+import hivemall.model.NewDenseModel;
 import hivemall.model.PredictionModel;
-import hivemall.model.SparseModel;
+import hivemall.model.NewSparseModel;
 import hivemall.model.WeightValue;
 import hivemall.mix.MixMessage.MixEventName;
 import hivemall.mix.client.MixClient;
@@ -55,7 +55,7 @@ public class MixServerTest extends HivemallTestBase {
 
         waitForState(server, ServerState.RUNNING);
 
-        PredictionModel model = new DenseModel(16777216);
+        PredictionModel model = new NewDenseModel(16777216);
         model.configureClock();
         MixClient client = null;
         try {
@@ -93,7 +93,7 @@ public class MixServerTest extends HivemallTestBase {
 
         waitForState(server, ServerState.RUNNING);
 
-        PredictionModel model = new DenseModel(16777216);
+        PredictionModel model = new NewDenseModel(16777216);
         model.configureClock();
         MixClient client = null;
         try {
@@ -151,7 +151,7 @@ public class MixServerTest extends HivemallTestBase {
     }
 
     private static void invokeClient(String groupId, int serverPort) throws InterruptedException {
-        PredictionModel model = new DenseModel(16777216);
+        PredictionModel model = new NewDenseModel(16777216);
         model.configureClock();
         MixClient client = null;
         try {
@@ -298,8 +298,8 @@ public class MixServerTest extends HivemallTestBase {
 
     private static void invokeClient01(String groupId, int serverPort, boolean denseModel, boolean cancelMix)
             throws InterruptedException {
-        PredictionModel model = denseModel ? new DenseModel(100)
-                : new SparseModel(100, false);
+        PredictionModel model = denseModel ? new NewDenseModel(100)
+                : new NewSparseModel(100, false);
         model.configureClock();
         MixClient client = null;
         try {

--- a/mixserv/src/test/java/hivemall/mix/server/MixServerTest.java
+++ b/mixserv/src/test/java/hivemall/mix/server/MixServerTest.java
@@ -55,7 +55,7 @@ public class MixServerTest extends HivemallTestBase {
 
         waitForState(server, ServerState.RUNNING);
 
-        PredictionModel model = new DenseModel(16777216, false);
+        PredictionModel model = new DenseModel(16777216);
         model.configureClock();
         MixClient client = null;
         try {
@@ -93,7 +93,7 @@ public class MixServerTest extends HivemallTestBase {
 
         waitForState(server, ServerState.RUNNING);
 
-        PredictionModel model = new DenseModel(16777216, false);
+        PredictionModel model = new DenseModel(16777216);
         model.configureClock();
         MixClient client = null;
         try {
@@ -151,7 +151,7 @@ public class MixServerTest extends HivemallTestBase {
     }
 
     private static void invokeClient(String groupId, int serverPort) throws InterruptedException {
-        PredictionModel model = new DenseModel(16777216, false);
+        PredictionModel model = new DenseModel(16777216);
         model.configureClock();
         MixClient client = null;
         try {
@@ -296,10 +296,10 @@ public class MixServerTest extends HivemallTestBase {
         serverExec.shutdown();
     }
 
-    private static void invokeClient01(String groupId, int serverPort, boolean denseModel,
-            boolean cancelMix) throws InterruptedException {
-        PredictionModel model = denseModel ? new DenseModel(100, false) : new SparseModel(100,
-            false);
+    private static void invokeClient01(String groupId, int serverPort, boolean denseModel, boolean cancelMix)
+            throws InterruptedException {
+        PredictionModel model = denseModel ? new DenseModel(100)
+                : new SparseModel(100, false);
         model.configureClock();
         MixClient client = null;
         try {

--- a/resources/ddl/define-all-as-permanent.hive
+++ b/resources/ddl/define-all-as-permanent.hive
@@ -338,7 +338,7 @@ CREATE FUNCTION tf as 'hivemall.ftvec.text.TermFrequencyUDAF' USING JAR '${hivem
 --------------------------
 
 DROP FUNCTION IF EXISTS train_regression;
-CREATE FUNCTION train_regression as 'hivemall.classifier.GeneralRegressionUDTF' USING JAR '${hivemall_jar}';
+CREATE FUNCTION train_regression as 'hivemall.regression.GeneralRegressionUDTF' USING JAR '${hivemall_jar}';
 
 DROP FUNCTION IF EXISTS train_logregr;
 CREATE FUNCTION train_logregr as 'hivemall.regression.LogressUDTF' USING JAR '${hivemall_jar}';

--- a/resources/ddl/define-all-as-permanent.hive
+++ b/resources/ddl/define-all-as-permanent.hive
@@ -13,6 +13,9 @@ CREATE FUNCTION hivemall_version as 'hivemall.HivemallVersionUDF' USING JAR '${h
 -- binary classification --
 ---------------------------
 
+DROP FUNCTION IF EXISTS train_classifier;
+CREATE FUNCTION train_classifier as 'hivemall.classifier.GeneralClassifierUDTF' USING JAR '${hivemall_jar}';
+
 DROP FUNCTION IF EXISTS train_perceptron;
 CREATE FUNCTION train_perceptron as 'hivemall.classifier.PerceptronUDTF' USING JAR '${hivemall_jar}';
 
@@ -334,6 +337,13 @@ CREATE FUNCTION tf as 'hivemall.ftvec.text.TermFrequencyUDAF' USING JAR '${hivem
 -- Regression functions --
 --------------------------
 
+DROP FUNCTION IF EXISTS train_regression;
+CREATE FUNCTION train_regression as 'hivemall.classifier.GeneralRegressionUDTF' USING JAR '${hivemall_jar}';
+
+DROP FUNCTION IF EXISTS train_logregr;
+CREATE FUNCTION train_logregr as 'hivemall.regression.LogressUDTF' USING JAR '${hivemall_jar}';
+
+-- alias for backward compatibility
 DROP FUNCTION IF EXISTS logress;
 CREATE FUNCTION logress as 'hivemall.regression.LogressUDTF' USING JAR '${hivemall_jar}';
 
@@ -688,3 +698,4 @@ CREATE FUNCTION xgboost_predict AS 'hivemall.xgboost.tools.XGBoostPredictUDTF' U
 
 DROP FUNCTION xgboost_multiclass_predict;
 CREATE FUNCTION xgboost_multiclass_predict AS 'hivemall.xgboost.tools.XGBoostMulticlassPredictUDTF' USING JAR '${hivemall_jar}';
+=======

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -2,12 +2,15 @@
 -- Hivemall: Hive scalable Machine Learning Library
 -----------------------------------------------------------------------------
 
-drop temporary function if exists  hivemall_version;
+drop temporary function if exists hivemall_version;
 create temporary function hivemall_version as 'hivemall.HivemallVersionUDF';
 
 ---------------------------
 -- binary classification --
 ---------------------------
+
+drop temporary function if exists train_classifier;
+create temporary function train_classifier as 'hivemall.regression.GeneralClassifierUDTF';
 
 drop temporary function if exists train_perceptron;
 create temporary function train_perceptron as 'hivemall.classifier.PerceptronUDTF';
@@ -329,6 +332,9 @@ create temporary function tf as 'hivemall.ftvec.text.TermFrequencyUDAF';
 --------------------------
 -- Regression functions --
 --------------------------
+
+drop temporary function if exists train_regression;
+create temporary function train_regression as 'hivemall.regression.GeneralRegressionUDTF';
 
 drop temporary function if exists logress;
 create temporary function logress as 'hivemall.regression.LogressUDTF';
@@ -698,5 +704,3 @@ log(10, n_docs / max2(1,df_t)) + 1.0;
 
 create temporary macro tfidf(tf FLOAT, df_t DOUBLE, n_docs DOUBLE)
 tf * (log(10, n_docs / max2(1,df_t)) + 1.0);
-
-

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -10,7 +10,7 @@ create temporary function hivemall_version as 'hivemall.HivemallVersionUDF';
 ---------------------------
 
 drop temporary function if exists train_classifier;
-create temporary function train_classifier as 'hivemall.regression.GeneralClassifierUDTF';
+create temporary function train_classifier as 'hivemall.classifier.GeneralClassifierUDTF';
 
 drop temporary function if exists train_perceptron;
 create temporary function train_perceptron as 'hivemall.classifier.PerceptronUDTF';

--- a/resources/ddl/define-all.spark
+++ b/resources/ddl/define-all.spark
@@ -11,6 +11,9 @@ sqlContext.sql("CREATE TEMPORARY FUNCTION hivemall_version AS 'hivemall.Hivemall
  * Binary classification
  */
 
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS train_classifier")
+sqlContext.sql("CREATE TEMPORARY FUNCTION train_classifier AS 'hivemall.classifier.GeneralClassifierUDTF'")
+
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS train_perceptron")
 sqlContext.sql("CREATE TEMPORARY FUNCTION train_perceptron AS 'hivemall.classifier.PerceptronUDTF'")
 
@@ -332,6 +335,9 @@ sqlContext.sql("CREATE TEMPORARY FUNCTION tf AS 'hivemall.ftvec.text.TermFrequen
 /**
  * Regression functions
  */
+
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS train_regression")
+sqlContext.sql("CREATE TEMPORARY FUNCTION train_regression AS 'hivemall.regression.GeneralRegressionUDTF'")
 
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS logress")
 sqlContext.sql("CREATE TEMPORARY FUNCTION logress AS 'hivemall.regression.LogressUDTF'")

--- a/resources/ddl/define-udfs.td.hql
+++ b/resources/ddl/define-udfs.td.hql
@@ -166,6 +166,8 @@ create temporary function tile as 'hivemall.geospatial.TileUDF';
 create temporary function map_url as 'hivemall.geospatial.MapURLUDF';
 create temporary function l2_norm as 'hivemall.tools.math.L2NormUDAF';
 create temporary function dimsum_mapper as 'hivemall.knn.similarity.DIMSUMMapperUDTF';
+create temporary function train_classifier as 'hivemall.classifier.GeneralClassifierUDTF';
+create temporary function train_regression as 'hivemall.regression.GeneralRegressionUDTF';
 
 -- NLP features
 create temporary function tokenize_ja as 'hivemall.nlp.tokenizer.KuromojiUDF';

--- a/spark/spark-2.0/src/test/scala/hivemall/mix/server/MixServerSuite.scala
+++ b/spark/spark-2.0/src/test/scala/hivemall/mix/server/MixServerSuite.scala
@@ -22,13 +22,12 @@ import java.util.Random
 import java.util.concurrent.{Executors, ExecutorService, TimeUnit}
 import java.util.logging.Logger
 
-import org.scalatest.{BeforeAndAfter, FunSuite}
-
-import hivemall.model.{NewDenseModel, PredictionModel, WeightValue
-import hivemall.mix.MixMessage.MixEventName
 import hivemall.mix.client.MixClient
+import hivemall.mix.MixMessage.MixEventName
 import hivemall.mix.server.MixServer.ServerState
-import hivemall.model.{DenseModel, PredictionModel, WeightValue}
+import hivemall.model.{DenseModel, PredictionModel}
+import hivemall.model.{NewDenseModel, PredictionModel}
+import hivemall.model.WeightValue
 import hivemall.utils.io.IOUtils
 import hivemall.utils.lang.CommandLineUtils
 import hivemall.utils.net.NetUtils

--- a/spark/spark-2.0/src/test/scala/hivemall/mix/server/MixServerSuite.scala
+++ b/spark/spark-2.0/src/test/scala/hivemall/mix/server/MixServerSuite.scala
@@ -22,6 +22,9 @@ import java.util.Random
 import java.util.concurrent.{Executors, ExecutorService, TimeUnit}
 import java.util.logging.Logger
 
+import org.scalatest.{BeforeAndAfter, FunSuite}
+
+import hivemall.model.{NewDenseModel, PredictionModel, WeightValue
 import hivemall.mix.MixMessage.MixEventName
 import hivemall.mix.client.MixClient
 import hivemall.mix.server.MixServer.ServerState
@@ -96,7 +99,7 @@ class MixServerSuite extends FunSuite with BeforeAndAfter {
         ignore(testName) {
           val clients = Executors.newCachedThreadPool()
           val numClients = nclient
-          val models = (0 until numClients).map(i => new DenseModel(ndims, false))
+          val models = (0 until numClients).map(i => new NewDenseModel(ndims, false))
           (0 until numClients).map { i =>
             clients.submit(new Runnable() {
               override def run(): Unit = {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Finalize #14 

## What type of PR is it?

Improvement, Feature

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-101

## How was this patch tested?

- Unit test
- Manual test on EMR

---

Todo:

- [x] Compare the accuracy of `-loss logloss` with the current `logress()` UDTF
- [x] Add document that includes general explanation of SGD, regularization and optimization techniques like [MLlib](http://spark.apache.org/docs/latest/mllib-optimization.html) and [sklearn](http://scikit-learn.org/stable/modules/sgd.html#mathematical-formulation)
- [x] Support `-mini_batch` option in a similar way to [what RegressionBaseUDTF does](https://github.com/takuti/incubator-hivemall/blob/5dc6f4eb5a8d8532201f6706673e2381d47d7e70/core/src/main/java/hivemall/regression/RegressionBaseUDTF.java#L247-L251); accumulate gradients over M samples, and update for mean value
- [x] ~~Save samples to external files as the other UDTFs (see LDA/pLSA UDTFs) and add `-iter` option~~ *This should be the other issue* [\[HIVEMALL-108\]](https://issues.apache.org/jira/browse/HIVEMALL-108)  
- [x] Manage cumulative loss for future `-iter` support
- [x] Anything else for mix-server-related things?