### PR TITLE
[HIVEMALL-115] Fix ranking AUC for all TP/FP recommendation

### DIFF
--- a/core/src/main/java/hivemall/evaluation/BinaryResponsesMeasures.java
+++ b/core/src/main/java/hivemall/evaluation/BinaryResponsesMeasures.java
@@ -191,6 +191,11 @@ public final class BinaryResponsesMeasures {
         // # of all possible <TP, FP> pairs
         int nPairs = nTruePositive * (recommendSize - nTruePositive);
 
+        // if there is no TP or no FP, it's meaningless for this metric (i.e., AUC=0.5)
+        if (nPairs == 0) {
+            return 0.5d;
+        }
+
         // AUC can equivalently be calculated by counting the portion of correctly ordered pairs
         return (double) nCorrectPairs / nPairs;
     }

--- a/core/src/test/java/hivemall/evaluation/BinaryResponsesMeasuresTest.java
+++ b/core/src/test/java/hivemall/evaluation/BinaryResponsesMeasuresTest.java
@@ -102,6 +102,16 @@ public class BinaryResponsesMeasuresTest {
 
         actual = BinaryResponsesMeasures.AUC(rankedList, groundTruth, 2);
         Assert.assertEquals(1.0d, actual, 0.0001d);
+
+        // meaningless case I: all TPs
+        List<Integer> groundTruthAllTruePositive = Arrays.asList(1, 3, 2, 6);
+        actual = BinaryResponsesMeasures.AUC(rankedList, groundTruthAllTruePositive, rankedList.size());
+        Assert.assertEquals(0.5d, actual, 0.0001d);
+
+        // meaningless case II: all FPs
+        List<Integer> groundTruthAllFalsePositive = Arrays.asList(7, 8, 9, 10);
+        actual = BinaryResponsesMeasures.AUC(rankedList, groundTruthAllFalsePositive, rankedList.size());
+        Assert.assertEquals(0.5d, actual, 0.0001d);
     }
 
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

The current ranking AUC returns NULL when all recommended items are TP (or FP). This PR fixes the issue by returning 0.5 as "meaningless" AUC for such input.

- Caused by: myui/hivemall#326
- Reference:
  - [LibRec](https://github.com/guoguibing/librec/blob/18176ed41027348ee2187d8686a1b2c0d4d39277/core/src/main/java/net/librec/eval/ranking/AUCEvaluator.java#L80-L83)
  - [MyMediaLite](https://github.com/zenogantner/MyMediaLite/blob/3a268110338b24627c8c2c973c0f9d03b151e2df/src/MyMediaLite/Eval/Measures/AUC.cs#L51-L52)

## What type of PR is it?

Bug Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-115

## How was this patch tested?

Manually (local & EMR)