### PR TITLE
[HIVEMALL-108] Support `-iter` option in generic predictors

### DIFF
--- a/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
@@ -261,7 +261,7 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
             } catch (Throwable e) {
                 throw new UDFArgumentException(e);
             }
-            this.inputBuf = buf = ByteBuffer.allocateDirect(1024 * 1024 * 10); // 10 MB
+            this.inputBuf = buf = ByteBuffer.allocateDirect(1024 * 1024); // 1 MB
             this.fileIO = dst = new NioStatefullSegment(file, false);
         }
 

--- a/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
@@ -177,8 +177,8 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
 
         this.iterations = Primitives.parseInt(cl.getOptionValue("iterations"), 10);
         if (iterations < 1) {
-            throw new UDFArgumentException(
-                "'-iterations' must be greater than or equals to 1: " + iterations);
+            throw new UDFArgumentException("'-iterations' must be greater than or equals to 1: "
+                    + iterations);
         }
 
         this.tol = Primitives.parseDouble(cl.getOptionValue("tolerance"), 1E-1d);
@@ -237,8 +237,8 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
         recordTrainSampleToTempFile(featureVector, target);
     }
 
-    protected void recordTrainSampleToTempFile(@Nonnull final FeatureValue[] featureVector, final float target)
-            throws HiveException {
+    protected void recordTrainSampleToTempFile(@Nonnull final FeatureValue[] featureVector,
+            final float target) throws HiveException {
         if (iterations == 1) {
             return;
         }
@@ -427,7 +427,7 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
 
         final Reporter reporter = getReporter();
         final Counters.Counter iterCounter = (reporter == null) ? null : reporter.getCounter(
-                "hivemall.GeneralLearnerBase$Counter", "iteration");
+            "hivemall.GeneralLearnerBase$Counter", "iteration");
 
         try {
             if (dst.getPosition() == 0L) {// run iterations w/o temporary file

--- a/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
@@ -469,8 +469,8 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
                 }
                 buf.flip();
 
-                int iter = 2;
-                for (; iter <= iterations; iter++) {
+                for (int iter = 2; iter <= iterations; iter++) {
+                    cvState.next();
                     reportProgress(reporter);
                     setCounterValue(iterCounter, iter);
 
@@ -491,17 +491,17 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
                         batchUpdate();
                     }
 
-                    if (cvState.isConverged(iter, numTrainingExamples)) {
+                    if (cvState.isConverged(numTrainingExamples)) {
                         break;
                     }
                 }
                 logger.info("Performed "
-                        + Math.min(iter, iterations)
+                        + cvState.getCurrentIteration()
                         + " iterations of "
                         + NumberUtils.formatNumber(numTrainingExamples)
                         + " training examples on memory (thus "
-                        + NumberUtils.formatNumber(numTrainingExamples * Math.min(iter, iterations))
-                        + " training updates in total) ");
+                        + NumberUtils.formatNumber(numTrainingExamples
+                                * cvState.getCurrentIteration()) + " training updates in total) ");
             } else {// read training examples in the temporary file and invoke train for each example
                 // write training examples in buffer to a temporary file
                 if (buf.remaining() > 0) {
@@ -522,8 +522,8 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
                 }
 
                 // run iterations
-                int iter = 2;
-                for (; iter <= iterations; iter++) {
+                for (int iter = 2; iter <= iterations; iter++) {
+                    cvState.next();
                     setCounterValue(iterCounter, iter);
 
                     buf.clear();
@@ -577,17 +577,17 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
                         batchUpdate();
                     }
 
-                    if (cvState.isConverged(iter, numTrainingExamples)) {
+                    if (cvState.isConverged(numTrainingExamples)) {
                         break;
                     }
                 }
                 logger.info("Performed "
-                        + Math.min(iter, iterations)
+                        + cvState.getCurrentIteration()
                         + " iterations of "
                         + NumberUtils.formatNumber(numTrainingExamples)
                         + " training examples on a secondary storage (thus "
-                        + NumberUtils.formatNumber(numTrainingExamples * Math.min(iter, iterations))
-                        + " training updates in total)");
+                        + NumberUtils.formatNumber(numTrainingExamples
+                                * cvState.getCurrentIteration()) + " training updates in total)");
             }
         } catch (Throwable e) {
             throw new HiveException("Exception caused in the iterative training", e);

--- a/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
@@ -83,7 +83,7 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
     private static final Log logger = LogFactory.getLog(GeneralLearnerBaseUDTF.class);
 
     public enum FeatureType {
-        String, Text, Integer, WritableInt, Long, WritableLong
+        JavaString, Text, JavaInteger, WritableInt, JavaLong, WritableLong
     }
 
     private ListObjectInspector featureListOI;
@@ -236,15 +236,15 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
         ObjectInspector featureRawOI = featureListOI.getListElementObjectInspector();
         HiveUtils.validateFeatureOI(featureRawOI);
         if (featureRawOI instanceof JavaStringObjectInspector) {
-            this.featureType = FeatureType.String;
+            this.featureType = FeatureType.JavaString;
         } else if (featureRawOI instanceof WritableStringObjectInspector) {
             this.featureType = FeatureType.Text;
         } else if (featureRawOI instanceof JavaIntObjectInspector) {
-            this.featureType = FeatureType.Integer;
+            this.featureType = FeatureType.JavaInteger;
         } else if (featureRawOI instanceof WritableIntObjectInspector) {
             this.featureType = FeatureType.WritableInt;
         } else if (featureRawOI instanceof JavaLongObjectInspector) {
-            this.featureType = FeatureType.Long;
+            this.featureType = FeatureType.JavaLong;
         } else if (featureRawOI instanceof WritableLongObjectInspector) {
             this.featureType = FeatureType.WritableLong;
         } else {
@@ -367,13 +367,13 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
             case Text:
                 feature = new Text((String) feature);
                 break;
-            case Integer:
+            case JavaInteger:
                 feature = Integer.parseInt((String) feature);
                 break;
             case WritableInt:
                 feature = new IntWritable(Integer.parseInt((String) feature));
                 break;
-            case Long:
+            case JavaLong:
                 feature = Long.parseLong((String) feature);
                 break;
             case WritableLong:
@@ -400,7 +400,7 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
             }
             final FeatureValue fv;
             if (parseFeature) {
-                if (featureType == FeatureType.String) {
+                if (featureType == FeatureType.JavaString) {
                     fv = FeatureValue.parseFeatureAsString((String) f);
                 } else {
                     fv = FeatureValue.parse(f); // = parse feature as Text

--- a/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
@@ -165,23 +165,31 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
         CommandLine cl = super.processOptions(argOIs);
 
         LossFunction lossFunction = LossFunctions.getLossFunction(getDefaultLossType());
-        if (cl.hasOption("loss_function")) {
-            try {
-                lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
-            } catch (Throwable e) {
-                throw new UDFArgumentException(e.getMessage());
+        int iterations = 10;
+        double tol = 1E-1d;
+
+        if (cl != null) {
+            if (cl.hasOption("loss_function")) {
+                try {
+                    lossFunction = LossFunctions.getLossFunction(cl.getOptionValue("loss_function"));
+                } catch (Throwable e) {
+                    throw new UDFArgumentException(e.getMessage());
+                }
             }
+            checkLossFunction(lossFunction);
+
+            iterations = Primitives.parseInt(cl.getOptionValue("iterations"), 10);
+            if (iterations < 1) {
+                throw new UDFArgumentException("'-iterations' must be greater than or equals to 1: "
+                        + iterations);
+            }
+
+            tol = Primitives.parseDouble(cl.getOptionValue("tolerance"), 1E-1d);
         }
-        checkLossFunction(lossFunction);
+
         this.lossFunction = lossFunction;
-
-        this.iterations = Primitives.parseInt(cl.getOptionValue("iterations"), 10);
-        if (iterations < 1) {
-            throw new UDFArgumentException("'-iterations' must be greater than or equals to 1: "
-                    + iterations);
-        }
-
-        this.tol = Primitives.parseDouble(cl.getOptionValue("tolerance"), 1E-1d);
+        this.iterations = iterations;
+        this.tol = tol;
 
         OptimizerOptions.propcessOptions(cl, optimizerOptions);
 

--- a/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
@@ -249,8 +249,8 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
             this.featureType = FeatureType.WritableLong;
         } else {
             throw new UDFArgumentException("Feature object inspector must be one of "
-                + "[JavaString, WritableString, JavaInt, WritableInt, Long, WritableLong]: "
-                + featureRawOI.toString());
+                    + "[JavaString, WritableString, JavaInt, WritableInt, Long, WritableLong]: "
+                    + featureRawOI.toString());
         }
         this.parseFeature = HiveUtils.isStringOI(featureRawOI);
         return HiveUtils.asPrimitiveObjectInspector(featureRawOI);
@@ -445,7 +445,7 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
     protected void update(@Nonnull final FeatureValue[] features, final float target,
             final float predicted) {
         float loss = lossFunction.loss(predicted, target);
-        cvState.incrLoss(loss); // retain cumulative loss to check convergence      
+        cvState.incrLoss(loss); // retain cumulative loss to check convergence
 
         final float dloss = lossFunction.dloss(predicted, target);
         if (is_mini_batch) {

--- a/core/src/main/java/hivemall/UDTFWithOptions.java
+++ b/core/src/main/java/hivemall/UDTFWithOptions.java
@@ -63,7 +63,7 @@ public abstract class UDTFWithOptions extends GenericUDTF {
         return mapredContext.getReporter();
     }
 
-    protected static void reportProgress(@Nonnull Reporter reporter) {
+    protected static void reportProgress(@Nullable Reporter reporter) {
         if (reporter != null) {
             synchronized (reporter) {
                 reporter.progress();

--- a/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
+++ b/core/src/main/java/hivemall/classifier/GeneralClassifierUDTF.java
@@ -42,7 +42,8 @@ public final class GeneralClassifierUDTF extends GeneralLearnerBaseUDTF {
     @Override
     protected String getLossOptionDescription() {
         return "Loss function [HingeLoss (default), LogLoss, SquaredHingeLoss, ModifiedHuberLoss, or\n"
-                + "a regression loss: SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, HuberLoss]";
+                + "a regression loss: SquaredLoss, QuantileLoss, EpsilonInsensitiveLoss, "
+                + "SquaredEpsilonInsensitiveLoss, HuberLoss]";
     }
 
     @Override

--- a/core/src/main/java/hivemall/common/ConversionState.java
+++ b/core/src/main/java/hivemall/common/ConversionState.java
@@ -38,7 +38,6 @@ public final class ConversionState {
     private double currLosses, prevLosses;
 
     private int curIter;
-    private float curEta;
 
     public ConversionState() {
         this(true, 0.005d);
@@ -51,8 +50,7 @@ public final class ConversionState {
         this.totalErrors = 0.d;
         this.currLosses = 0.d;
         this.prevLosses = Double.POSITIVE_INFINITY;
-        this.curIter = 0;
-        this.curEta = Float.NaN;
+        this.curIter = 1;
     }
 
     public double getTotalErrors() {
@@ -83,20 +81,16 @@ public final class ConversionState {
         return currLosses > prevLosses;
     }
 
-    public boolean isConverged(final int iter, final long obserbedTrainingExamples) {
+    public boolean isConverged(final long obserbedTrainingExamples) {
         if (conversionCheck == false) {
-            this.prevLosses = currLosses;
-            this.currLosses = 0.d;
             return false;
         }
 
         if (currLosses > prevLosses) {
             if (logger.isInfoEnabled()) {
-                logger.info("Iteration #" + iter + " currLoss `" + currLosses + "` > prevLosses `"
-                        + prevLosses + '`');
+                logger.info("Iteration #" + curIter + " currLoss `" + currLosses
+                        + "` > prevLosses `" + prevLosses + '`');
             }
-            this.prevLosses = currLosses;
-            this.currLosses = 0.d;
             this.readyToFinishIterations = false;
             return false;
         }
@@ -105,7 +99,7 @@ public final class ConversionState {
         if (changeRate < convergenceRate) {
             if (readyToFinishIterations) {
                 // NOTE: never be true at the first iteration where prevLosses == Double.POSITIVE_INFINITY
-                logger.info("Training converged at " + iter + "-th iteration. [curLosses="
+                logger.info("Training converged at " + curIter + "-th iteration. [curLosses="
                         + currLosses + ", prevLosses=" + prevLosses + ", changeRate=" + changeRate
                         + ']');
                 return true;
@@ -114,33 +108,24 @@ public final class ConversionState {
             }
         } else {
             if (logger.isDebugEnabled()) {
-                logger.debug("Iteration #" + iter + " [curLosses=" + currLosses + ", prevLosses="
-                        + prevLosses + ", changeRate=" + changeRate + ", #trainingExamples="
-                        + obserbedTrainingExamples + ']');
+                logger.debug("Iteration #" + curIter + " [curLosses=" + currLosses
+                        + ", prevLosses=" + prevLosses + ", changeRate=" + changeRate
+                        + ", #trainingExamples=" + obserbedTrainingExamples + ']');
             }
             this.readyToFinishIterations = false;
         }
 
-        this.prevLosses = currLosses;
-        this.currLosses = 0.d;
         return false;
     }
 
-    public void logState(int iter, float eta) {
-        if (logger.isInfoEnabled()) {
-            logger.info("Iteration #" + iter + " [curLoss=" + currLosses + ", prevLoss="
-                    + prevLosses + ", eta=" + eta + ']');
-        }
-        this.curIter = iter;
-        this.curEta = eta;
+    public void next() {
+        this.prevLosses = currLosses;
+        this.currLosses = 0.d;
+        this.curIter++;
     }
 
     public int getCurrentIteration() {
         return curIter;
-    }
-
-    public float getCurrentEta() {
-        return curEta;
     }
 
 }

--- a/core/src/main/java/hivemall/common/ConversionState.java
+++ b/core/src/main/java/hivemall/common/ConversionState.java
@@ -25,20 +25,20 @@ public final class ConversionState {
     private static final Log logger = LogFactory.getLog(ConversionState.class);
 
     /** Whether to check conversion */
-    protected final boolean conversionCheck;
+    private final boolean conversionCheck;
     /** Threshold to determine convergence */
-    protected final double convergenceRate;
+    private final double convergenceRate;
 
     /** being ready to end iteration */
-    protected boolean readyToFinishIterations;
+    private boolean readyToFinishIterations;
 
     /** The cumulative errors in the training */
-    protected double totalErrors;
+    private double totalErrors;
     /** The cumulative losses in an iteration */
-    protected double currLosses, prevLosses;
+    private double currLosses, prevLosses;
 
-    protected int curIter;
-    protected float curEta;
+    private int curIter;
+    private float curEta;
 
     public ConversionState() {
         this(true, 0.005d);

--- a/core/src/main/java/hivemall/fm/FactorizationMachineUDTF.java
+++ b/core/src/main/java/hivemall/fm/FactorizationMachineUDTF.java
@@ -20,11 +20,11 @@ package hivemall.fm;
 
 import hivemall.UDTFWithOptions;
 import hivemall.common.ConversionState;
+import hivemall.fm.FMStringFeatureMapModel.Entry;
 import hivemall.optimizer.EtaEstimator;
 import hivemall.optimizer.LossFunctions;
 import hivemall.optimizer.LossFunctions.LossFunction;
 import hivemall.optimizer.LossFunctions.LossType;
-import hivemall.fm.FMStringFeatureMapModel.Entry;
 import hivemall.utils.collections.IMapIterator;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.io.FileUtils;
@@ -539,8 +539,8 @@ public class FactorizationMachineUDTF extends UDTFWithOptions {
                 }
                 inputBuf.flip();
 
-                int iter = 2;
-                for (; iter <= iterations; iter++) {
+                for (int iter = 2; iter <= iterations; iter++) {
+                    _cvState.next();
                     reportProgress(reporter);
                     setCounterValue(iterCounter, iter);
 
@@ -557,12 +557,12 @@ public class FactorizationMachineUDTF extends UDTFWithOptions {
                         ++_t;
                         train(x, y, adaregr);
                     }
-                    if (_cvState.isConverged(iter, numTrainingExamples)) {
+                    if (_cvState.isConverged(numTrainingExamples)) {
                         break;
                     }
                     inputBuf.rewind();
                 }
-                LOG.info("Performed " + Math.min(iter, iterations) + " iterations of "
+                LOG.info("Performed " + _cvState.getCurrentIteration() + " iterations of "
                         + NumberUtils.formatNumber(numTrainingExamples)
                         + " training examples on memory (thus " + NumberUtils.formatNumber(_t)
                         + " training updates in total) ");
@@ -587,8 +587,8 @@ public class FactorizationMachineUDTF extends UDTFWithOptions {
                 }
 
                 // run iterations
-                int iter = 2;
-                for (; iter <= iterations; iter++) {
+                for (int iter = 2; iter <= iterations; iter++) {
+                    _cvState.next();
                     setCounterValue(iterCounter, iter);
 
                     inputBuf.clear();
@@ -639,11 +639,11 @@ public class FactorizationMachineUDTF extends UDTFWithOptions {
                         }
                         inputBuf.compact();
                     }
-                    if (_cvState.isConverged(iter, numTrainingExamples)) {
+                    if (_cvState.isConverged(numTrainingExamples)) {
                         break;
                     }
                 }
-                LOG.info("Performed " + Math.min(iter, iterations) + " iterations of "
+                LOG.info("Performed " + _cvState.getCurrentIteration() + " iterations of "
                         + NumberUtils.formatNumber(numTrainingExamples)
                         + " training examples on a secondary storage (thus "
                         + NumberUtils.formatNumber(_t) + " training updates in total)");

--- a/core/src/main/java/hivemall/mf/BPRMatrixFactorizationUDTF.java
+++ b/core/src/main/java/hivemall/mf/BPRMatrixFactorizationUDTF.java
@@ -20,8 +20,8 @@ package hivemall.mf;
 
 import hivemall.UDTFWithOptions;
 import hivemall.common.ConversionState;
-import hivemall.optimizer.EtaEstimator;
 import hivemall.mf.FactorizedModel.RankInitScheme;
+import hivemall.optimizer.EtaEstimator;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.io.FileUtils;
 import hivemall.utils.io.NioFixedSegment;
@@ -479,8 +479,8 @@ public final class BPRMatrixFactorizationUDTF extends UDTFWithOptions implements
                 }
                 inputBuf.flip();
 
-                int iter = 2;
-                for (; iter <= iterations; iter++) {
+                for (int iter = 2; iter <= iterations; iter++) {
+                    cvState.next();
                     reportProgress(reporter);
                     setCounterValue(iterCounter, iter);
 
@@ -493,8 +493,7 @@ public final class BPRMatrixFactorizationUDTF extends UDTFWithOptions implements
                         train(u, i, j);
                     }
                     cvState.multiplyLoss(0.5d);
-                    cvState.logState(iter, eta());
-                    if (cvState.isConverged(iter, numTrainingExamples)) {
+                    if (cvState.isConverged(numTrainingExamples)) {
                         break;
                     }
                     if (cvState.isLossIncreased()) {
@@ -504,7 +503,7 @@ public final class BPRMatrixFactorizationUDTF extends UDTFWithOptions implements
                     }
                     inputBuf.rewind();
                 }
-                LOG.info("Performed " + Math.min(iter, iterations) + " iterations of "
+                LOG.info("Performed " + cvState.getCurrentIteration() + " iterations of "
                         + NumberUtils.formatNumber(numTrainingExamples)
                         + " training examples on memory (thus " + NumberUtils.formatNumber(count)
                         + " training updates in total) ");
@@ -531,8 +530,8 @@ public final class BPRMatrixFactorizationUDTF extends UDTFWithOptions implements
                 }
 
                 // run iterations
-                int iter = 2;
-                for (; iter <= iterations; iter++) {
+                for (int iter = 2; iter <= iterations; iter++) {
+                    cvState.next();
                     setCounterValue(iterCounter, iter);
 
                     inputBuf.clear();
@@ -569,8 +568,7 @@ public final class BPRMatrixFactorizationUDTF extends UDTFWithOptions implements
                         inputBuf.compact();
                     }
                     cvState.multiplyLoss(0.5d);
-                    cvState.logState(iter, eta());
-                    if (cvState.isConverged(iter, numTrainingExamples)) {
+                    if (cvState.isConverged(numTrainingExamples)) {
                         break;
                     }
                     if (cvState.isLossIncreased()) {
@@ -579,7 +577,7 @@ public final class BPRMatrixFactorizationUDTF extends UDTFWithOptions implements
                         etaEstimator.update(0.5f);
                     }
                 }
-                LOG.info("Performed " + Math.min(iter, iterations) + " iterations of "
+                LOG.info("Performed " + cvState.getCurrentIteration() + " iterations of "
                         + NumberUtils.formatNumber(numTrainingExamples)
                         + " training examples using a secondary storage (thus "
                         + NumberUtils.formatNumber(count) + " training updates in total)");

--- a/core/src/main/java/hivemall/mf/OnlineMatrixFactorizationUDTF.java
+++ b/core/src/main/java/hivemall/mf/OnlineMatrixFactorizationUDTF.java
@@ -477,8 +477,8 @@ public abstract class OnlineMatrixFactorizationUDTF extends UDTFWithOptions impl
                 }
                 inputBuf.flip();
 
-                int iter = 2;
-                for (; iter <= iterations; iter++) {
+                for (int iter = 2; iter <= iterations; iter++) {
+                    cvState.next();
                     reportProgress(reporter);
                     setCounterValue(iterCounter, iter);
 
@@ -491,12 +491,12 @@ public abstract class OnlineMatrixFactorizationUDTF extends UDTFWithOptions impl
                         train(user, item, rating);
                     }
                     cvState.multiplyLoss(0.5d);
-                    if (cvState.isConverged(iter, numTrainingExamples)) {
+                    if (cvState.isConverged(numTrainingExamples)) {
                         break;
                     }
                     inputBuf.rewind();
                 }
-                logger.info("Performed " + Math.min(iter, iterations) + " iterations of "
+                logger.info("Performed " + cvState.getCurrentIteration() + " iterations of "
                         + NumberUtils.formatNumber(numTrainingExamples)
                         + " training examples on memory (thus " + NumberUtils.formatNumber(count)
                         + " training updates in total) ");
@@ -523,8 +523,8 @@ public abstract class OnlineMatrixFactorizationUDTF extends UDTFWithOptions impl
                 }
 
                 // run iterations
-                int iter = 2;
-                for (; iter <= iterations; iter++) {
+                for (int iter = 2; iter <= iterations; iter++) {
+                    cvState.next();
                     setCounterValue(iterCounter, iter);
 
                     inputBuf.clear();
@@ -561,11 +561,11 @@ public abstract class OnlineMatrixFactorizationUDTF extends UDTFWithOptions impl
                         inputBuf.compact();
                     }
                     cvState.multiplyLoss(0.5d);
-                    if (cvState.isConverged(iter, numTrainingExamples)) {
+                    if (cvState.isConverged(numTrainingExamples)) {
                         break;
                     }
                 }
-                logger.info("Performed " + Math.min(iter, iterations) + " iterations of "
+                logger.info("Performed " + cvState.getCurrentIteration() + " iterations of "
                         + NumberUtils.formatNumber(numTrainingExamples)
                         + " training examples using a secondary storage (thus "
                         + NumberUtils.formatNumber(count) + " training updates in total)");

--- a/core/src/main/java/hivemall/model/FeatureValue.java
+++ b/core/src/main/java/hivemall/model/FeatureValue.java
@@ -23,16 +23,16 @@ import hivemall.utils.io.NIOUtils;
 import hivemall.utils.lang.Preconditions;
 import hivemall.utils.lang.SizeOf;
 
+import java.nio.ByteBuffer;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.apache.hadoop.io.Text;
 
-import java.nio.ByteBuffer;
-
 public final class FeatureValue {
 
-    private/* final */Object feature;
+    private/* final */Object feature; // possible types: String, Text, IntWritable, LongWritable
     private/* final */double value;
 
     public FeatureValue() {}// used for Probe
@@ -89,7 +89,7 @@ public final class FeatureValue {
     }
 
     public void readFrom(@Nonnull final ByteBuffer src) {
-        this.feature = new Text(NIOUtils.getString(src));
+        this.feature = NIOUtils.getString(src);
         this.value = src.getDouble();
     }
 

--- a/core/src/main/java/hivemall/model/FeatureValue.java
+++ b/core/src/main/java/hivemall/model/FeatureValue.java
@@ -48,7 +48,6 @@ public final class FeatureValue {
     }
 
     public FeatureValue(@Nonnull ByteBuffer src) {
-        super();
         readFrom(src);
     }
 

--- a/core/src/main/java/hivemall/model/FeatureValue.java
+++ b/core/src/main/java/hivemall/model/FeatureValue.java
@@ -19,11 +19,7 @@
 package hivemall.model;
 
 import hivemall.utils.hashing.MurmurHash3;
-import hivemall.utils.io.NIOUtils;
 import hivemall.utils.lang.Preconditions;
-import hivemall.utils.lang.SizeOf;
-
-import java.nio.ByteBuffer;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -32,7 +28,7 @@ import org.apache.hadoop.io.Text;
 
 public final class FeatureValue {
 
-    private/* final */Object feature; // possible types: String, Text, IntWritable, LongWritable
+    private/* final */Object feature; // possible types: String, Text, Integer, Long
     private/* final */double value;
 
     public FeatureValue() {}// used for Probe
@@ -45,10 +41,6 @@ public final class FeatureValue {
     public FeatureValue(Object f, double v) {
         this.feature = f;
         this.value = v;
-    }
-
-    public FeatureValue(@Nonnull ByteBuffer src) {
-        readFrom(src);
     }
 
     @SuppressWarnings("unchecked")
@@ -80,16 +72,6 @@ public final class FeatureValue {
 
     public void setValue(double value) {
         this.value = value;
-    }
-
-    public void writeTo(@Nonnull final ByteBuffer dst) {
-        NIOUtils.putString(getFeatureAsString(), dst);
-        dst.putDouble(value);
-    }
-
-    public void readFrom(@Nonnull final ByteBuffer src) {
-        this.feature = NIOUtils.getString(src);
-        this.value = src.getDouble();
     }
 
     @Nullable
@@ -181,17 +163,4 @@ public final class FeatureValue {
             probe.value = 1.d;
         }
     }
-
-    public static int requiredBytes(@Nonnull final FeatureValue[] x) {
-        int ret = 0;
-        for (FeatureValue f : x) {
-            assert (f != null);
-            String feature = f.getFeatureAsString();
-            ret += SizeOf.CHAR * feature.length(); // feature as String (even if it's Integer)
-            ret += SizeOf.INT; // NIOUtils.putString() first puts the length of string before string itself
-            ret += SizeOf.DOUBLE; // value
-        }
-        return ret;
-    }
-
 }

--- a/core/src/main/java/hivemall/optimizer/Optimizer.java
+++ b/core/src/main/java/hivemall/optimizer/Optimizer.java
@@ -51,7 +51,7 @@ public interface Optimizer {
         @Nonnull
         protected final Regularization _reg;
         @Nonnegative
-        protected int _numStep = 1;
+        protected long _numStep = 1L;
 
         public OptimizerBase(@Nonnull Map<String, String> options) {
             this._eta = EtaEstimator.get(options);

--- a/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
+++ b/core/src/main/java/hivemall/regression/GeneralRegressionUDTF.java
@@ -41,8 +41,8 @@ public final class GeneralRegressionUDTF extends GeneralLearnerBaseUDTF {
 
     @Override
     protected String getLossOptionDescription() {
-        return "Loss function [default: SquaredLoss/squared, QuantileLoss/quantile, "
-                + "EpsilonInsensitiveLoss/epsilon_insensitive, HuberLoss/huber]";
+        return "Loss function [SquaredLoss (default), QuantileLoss, EpsilonInsensitiveLoss, "
+                + "SquaredEpsilonInsensitiveLoss, HuberLoss]";
     }
 
     @Override

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -96,7 +96,7 @@ public class GeneralClassifierUDTFTest {
 
         udtf.process(new Object[] {x, y});
 
-        udtf.closeWithoutModelReset();
+        udtf.finalizeTraining();
 
         float score = udtf.predict(udtf.parseFeatures(x));
         int predicted = score > 0.f ? 1 : 0;
@@ -129,7 +129,7 @@ public class GeneralClassifierUDTFTest {
             udtf.process(new Object[] {samplesList.get(i), labels[i]});
         }
 
-        udtf.closeWithoutModelReset();
+        udtf.finalizeTraining();
 
         double cumLoss = udtf.getCumulativeLoss();
         println("Cumulative loss: " + cumLoss);
@@ -227,7 +227,7 @@ public class GeneralClassifierUDTFTest {
         news20.close();
 
         // perform SGD iterations
-        udtf.closeWithoutModelReset();
+        udtf.finalizeTraining();
 
         int numTests = 0;
         int numCorrect = 0;

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -18,7 +18,6 @@
  */
 package hivemall.classifier;
 
-import hivemall.regression.GeneralRegressionUDTF;
 import hivemall.utils.math.MathUtils;
 
 import java.io.BufferedReader;
@@ -113,7 +112,7 @@ public class GeneralClassifierUDTFTest {
             throws Exception {
         int y = 0;
 
-        GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
+        GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
         ObjectInspector valueOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
         ListObjectInspector featureListOI = ObjectInspectorFactory.getStandardListObjectInspector(featureOI);
 

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -82,6 +82,27 @@ public class GeneralClassifierUDTFTest {
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
     }
 
+    @Test
+    public void testNoOptions() throws Exception {
+        List<String> x = Arrays.asList("1:-2", "2:-1");
+        int y = 0;
+
+        GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI});
+
+        udtf.process(new Object[] {x, y});
+
+        udtf.closeWithoutModelReset();
+
+        float score = udtf.predict(udtf.parseFeatures(x));
+        int predicted = score > 0.f ? 1 : 0;
+        Assert.assertTrue(y == predicted);
+    }
+
     private void run(@Nonnull String options) throws Exception {
         println(options);
 

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -133,7 +133,9 @@ public class GeneralClassifierUDTFTest {
 
         double cumLoss = udtf.getCumulativeLoss();
         println("Cumulative loss: " + cumLoss);
-        Assert.assertTrue(cumLoss / samplesList.size() < 0.5d);
+        double normalizedLoss = cumLoss / samplesList.size();
+        Assert.assertTrue("cumLoss: " + cumLoss + ", normalizedLoss: " + normalizedLoss
+                + "\noptions: " + options, normalizedLoss < 0.5d);
 
         int numTests = 0;
         int numCorrect = 0;
@@ -173,7 +175,7 @@ public class GeneralClassifierUDTFTest {
 
                 for (String loss : lossFunctions) {
                     String options = "-opt " + opt + " -reg " + reg + " -loss " + loss
-                            + " -tol 1e-3f -iter 512";
+                            + " -cv_rate 0.005 -iter 512";
 
                     // sparse
                     run(options);
@@ -200,7 +202,7 @@ public class GeneralClassifierUDTFTest {
         ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
         ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
             PrimitiveObjectInspectorFactory.javaStringObjectInspector,
-            "-opt SGD -loss logloss -reg L2 -lambda 0.1 -tol 1e-3");
+            "-opt SGD -loss logloss -reg L2 -lambda 0.1 -cv_rate 0.005");
 
         udtf.initialize(new ObjectInspector[] {stringListOI, intOI, params});
 

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -175,7 +175,7 @@ public class GeneralClassifierUDTFTest {
 
                 for (String loss : lossFunctions) {
                     String options = "-opt " + opt + " -reg " + reg + " -loss " + loss
-                            + " -cv_rate 0.005 -iter 512";
+                            + " -cv_rate 0.001 -iter 512";
 
                     // sparse
                     run(options);

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -109,7 +109,8 @@ public class GeneralClassifierUDTFTest {
         Assert.assertTrue(y == predicted);
     }
 
-    private void testFeature(List<?> x, ObjectInspector featureOI, Class featureClass) throws Exception {
+    private void testFeature(List<?> x, ObjectInspector featureOI, Class featureClass)
+            throws Exception {
         int y = 0;
 
         GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
@@ -133,10 +134,13 @@ public class GeneralClassifierUDTFTest {
 
         Class modelFeatureClass = modelFeatures.get(0).getClass();
         for (Object modelFeature : modelFeatures) {
-            Assert.assertEquals("All model features must have same type", modelFeatureClass, modelFeature.getClass());
+            Assert.assertEquals("All model features must have same type", modelFeatureClass,
+                modelFeature.getClass());
         }
 
-        Assert.assertEquals("Model feature must correspond to UDTF output feature's object inspector", featureClass, modelFeatureClass);
+        Assert.assertEquals(
+            "Model feature must correspond to UDTF output feature's object inspector",
+            featureClass, modelFeatureClass);
     }
 
     @Test

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -84,6 +84,26 @@ public class GeneralRegressionUDTFTest {
         udtf.initialize(new ObjectInspector[] {stringListOI, floatOI, params});
     }
 
+    @Test
+    public void testNoOptions() throws Exception {
+        List<String> x = Arrays.asList("1:-2", "2:-1");
+        float y = 0.f;
+
+        GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
+        ObjectInspector intOI = PrimitiveObjectInspectorFactory.javaFloatObjectInspector;
+        ObjectInspector stringOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(stringOI);
+
+        udtf.initialize(new ObjectInspector[] {stringListOI, intOI});
+
+        udtf.process(new Object[] {x, y});
+
+        udtf.closeWithoutModelReset();
+
+        float predicted = udtf.predict(udtf.parseFeatures(x));
+        Assert.assertEquals(y, predicted, 1E-5);
+    }
+
     private void run(@Nonnull String options) throws Exception {
         println(options);
 

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -98,7 +98,7 @@ public class GeneralRegressionUDTFTest {
 
         udtf.process(new Object[] {x, y});
 
-        udtf.closeWithoutModelReset();
+        udtf.finalizeTraining();
 
         float predicted = udtf.predict(udtf.parseFeatures(x));
         Assert.assertEquals(y, predicted, 1E-5);
@@ -143,7 +143,7 @@ public class GeneralRegressionUDTFTest {
             udtf.process(new Object[] {samplesList.get(i), (Float) ys.get(i)});
         }
 
-        udtf.closeWithoutModelReset();
+        udtf.finalizeTraining();
 
         double cumLoss = udtf.getCumulativeLoss();
         println("Cumulative loss: " + cumLoss);

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -25,11 +25,17 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.Collector;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -102,6 +108,78 @@ public class GeneralRegressionUDTFTest {
 
         float predicted = udtf.predict(udtf.parseFeatures(x));
         Assert.assertEquals(y, predicted, 1E-5);
+    }
+
+    private void testFeature(List<?> x, ObjectInspector featureOI, Class featureClass) throws Exception {
+        float y = 0.f;
+
+        GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
+        ObjectInspector valueOI = PrimitiveObjectInspectorFactory.javaFloatObjectInspector;
+        ListObjectInspector featureListOI = ObjectInspectorFactory.getStandardListObjectInspector(featureOI);
+
+        udtf.initialize(new ObjectInspector[] {featureListOI, valueOI});
+
+        final List<Object> modelFeatures = new ArrayList<Object>();
+        udtf.setCollector(new Collector() {
+            @Override
+            public void collect(Object input) throws HiveException {
+                Object[] forwardMapObj = (Object[]) input;
+                modelFeatures.add(forwardMapObj[0]);
+            }
+        });
+
+        udtf.process(new Object[] {x, y});
+
+        udtf.close();
+
+        Class modelFeatureClass = modelFeatures.get(0).getClass();
+        for (Object modelFeature : modelFeatures) {
+            Assert.assertEquals("All model features must have same type", modelFeatureClass, modelFeature.getClass());
+        }
+
+        Assert.assertEquals("Model feature must correspond to UDTF output feature's object inspector", featureClass, modelFeatureClass);
+    }
+
+    @Test
+    public void testStringFeature() throws Exception {
+        List<String> x = Arrays.asList("1:-2", "2:-1");
+        ObjectInspector featureOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        testFeature(x, featureOI, String.class);
+    }
+
+    @Test
+    public void testTextFeature() throws Exception {
+        List<Text> x = Arrays.asList(new Text("1:-2"), new Text("2:-1"));
+        ObjectInspector featureOI = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
+        testFeature(x, featureOI, Text.class);
+    }
+
+    @Test
+    public void testIntegerFeature() throws Exception {
+        List<Integer> x = Arrays.asList(111, 222);
+        ObjectInspector featureOI = PrimitiveObjectInspectorFactory.javaIntObjectInspector;
+        testFeature(x, featureOI, Integer.class);
+    }
+
+    @Test
+    public void testWritableIntFeature() throws Exception {
+        List<IntWritable> x = Arrays.asList(new IntWritable(111), new IntWritable(222));
+        ObjectInspector featureOI = PrimitiveObjectInspectorFactory.writableIntObjectInspector;
+        testFeature(x, featureOI, IntWritable.class);
+    }
+
+    @Test
+    public void testLongFeature() throws Exception {
+        List<Long> x = Arrays.asList(111L, 222L);
+        ObjectInspector featureOI = PrimitiveObjectInspectorFactory.javaLongObjectInspector;
+        testFeature(x, featureOI, Long.class);
+    }
+
+    @Test
+    public void testWritableLongFeature() throws Exception {
+        List<LongWritable> x = Arrays.asList(new LongWritable(111L), new LongWritable(222L));
+        ObjectInspector featureOI = PrimitiveObjectInspectorFactory.writableLongObjectInspector;
+        testFeature(x, featureOI, LongWritable.class);
     }
 
     private void run(@Nonnull String options) throws Exception {

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -110,7 +110,8 @@ public class GeneralRegressionUDTFTest {
         Assert.assertEquals(y, predicted, 1E-5);
     }
 
-    private void testFeature(List<?> x, ObjectInspector featureOI, Class featureClass) throws Exception {
+    private void testFeature(List<?> x, ObjectInspector featureOI, Class featureClass)
+            throws Exception {
         float y = 0.f;
 
         GeneralRegressionUDTF udtf = new GeneralRegressionUDTF();
@@ -134,10 +135,13 @@ public class GeneralRegressionUDTFTest {
 
         Class modelFeatureClass = modelFeatures.get(0).getClass();
         for (Object modelFeature : modelFeatures) {
-            Assert.assertEquals("All model features must have same type", modelFeatureClass, modelFeature.getClass());
+            Assert.assertEquals("All model features must have same type", modelFeatureClass,
+                modelFeature.getClass());
         }
 
-        Assert.assertEquals("Model feature must correspond to UDTF output feature's object inspector", featureClass, modelFeatureClass);
+        Assert.assertEquals(
+            "Model feature must correspond to UDTF output feature's object inspector",
+            featureClass, modelFeatureClass);
     }
 
     @Test
@@ -238,7 +242,7 @@ public class GeneralRegressionUDTFTest {
 
         accum = 0.f;
         for (int i = 0; i < numSamples; i++) {
-                float y = ys.get(i).floatValue();
+            float y = ys.get(i).floatValue();
 
             float predicted = udtf.predict(udtf.parseFeatures(samplesList.get(i)));
             println("Predicted: " + predicted + ", Actual: " + y);

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -147,7 +147,9 @@ public class GeneralRegressionUDTFTest {
 
         double cumLoss = udtf.getCumulativeLoss();
         println("Cumulative loss: " + cumLoss);
-        Assert.assertTrue(cumLoss / numTrain < 0.1d);
+        double normalizedLoss = cumLoss / numTrain;
+        Assert.assertTrue("cumLoss: " + cumLoss + ", normalizedLoss: " + normalizedLoss
+                + "\noptions: " + options, normalizedLoss < 0.1d);
 
         float accum = 0.f;
 

--- a/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressionUDTFTest.java
@@ -160,9 +160,9 @@ public class GeneralRegressionUDTFTest {
             accum += Math.abs(y - predicted);
         }
 
-        float err = accum / (numSamples - numTrain);
-        println("Mean absolute error: " + err);
-        Assert.assertTrue(err < 0.2f);
+        float mae = accum / (numSamples - numTrain);
+        println("Mean absolute error: " + mae);
+        Assert.assertTrue("accum: " + accum + ", mae:" + mae + "\noptions: " + options, mae < 0.2f);
     }
 
     @Test
@@ -180,7 +180,7 @@ public class GeneralRegressionUDTFTest {
 
                 for (String loss : lossFunctions) {
                     String options = "-opt " + opt + " -reg " + reg + " -loss " + loss
-                            + " -lambda 1e-6 -tol 1e-3f -iter 512";
+                            + " -lambda 1e-6 -cv_rate 0.005 -iter 512";
 
                     // sparse
                     run(options);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Support `-iter` option in both **generic classifier** and **regression** by buffering input samples, with an auxiliary `-tol` option.

Ref. #79 

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-108

## How was this patch tested?

- Unit test
  - Passed with the same test cases which were used for the previous "manual" iteration using for-loops
- Manual test on EMR
  - Same as what I did in #79

## How to use this feature?

Nothing has been changed except for the new options :)

---

### Notice

In order to check convergence, this PR adds `-tol` option; it is not `-eps` as pLSA #71 and LDA #66 have, because `-eps` already exists in generic predictors as an option for adagrad/adadelta. For the sake of unifying interface, `train_lda` and `train_plsa` might need to support `-tol` as alias of the existing `-eps` option. If we do so, it could be a part of [HIVEMALL-120](https://issues.apache.org/jira/browse/HIVEMALL-120).