### PR TITLE
[HIVEMALL-80] Allow array<struct> type as the first parameter to ndcg

### DIFF
--- a/core/src/main/java/hivemall/evaluation/NDCGUDAF.java
+++ b/core/src/main/java/hivemall/evaluation/NDCGUDAF.java
@@ -64,7 +64,8 @@ public final class NDCGUDAF extends AbstractGenericUDAFResolver {
         }
 
         ListTypeInfo arg1type = HiveUtils.asListTypeInfo(typeInfo[0]);
-        if (!HiveUtils.isPrimitiveTypeInfo(arg1type.getListElementTypeInfo())) {
+        if (!HiveUtils.isPrimitiveTypeInfo(arg1type.getListElementTypeInfo()) 
+            && !HiveUtils.isStructTypeInfo(arg1type.getListElementTypeInfo())) {
             throw new UDFArgumentTypeException(0,
                     "The first argument `array rankItems` is invalid form: " + typeInfo[0]);
         }


### PR DESCRIPTION

## What changes were proposed in this pull request?

Fix for checking the parameters to ndcg to allow struct types (which allows graded response measures)

## What type of PR is it?

Bug Fix

## What is the Jira issue?

HIVEMALL-80

## How was this patch tested?

Tested on our Hive cluster.

