### PR TITLE
[HIVEMALL-130] Support user-defined dictionary for `tokenize_ja`

### DIFF
--- a/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
+++ b/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
@@ -298,6 +298,10 @@ public final class HiveUtils {
                 && isNumberListOI(((ListObjectInspector) oi).getListElementObjectInspector());
     }
 
+    public static boolean isConstListOI(@Nonnull final ObjectInspector oi) {
+        return ObjectInspectorUtils.isConstantObjectInspector(oi) && isListOI(oi);
+    }
+
     public static boolean isConstString(@Nonnull final ObjectInspector oi) {
         return ObjectInspectorUtils.isConstantObjectInspector(oi) && isStringOI(oi);
     }

--- a/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
+++ b/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
@@ -27,6 +27,7 @@ import static hivemall.HivemallConstants.INT_TYPE_NAME;
 import static hivemall.HivemallConstants.SMALLINT_TYPE_NAME;
 import static hivemall.HivemallConstants.STRING_TYPE_NAME;
 import static hivemall.HivemallConstants.TINYINT_TYPE_NAME;
+import static hivemall.HivemallConstants.VOID_TYPE_NAME;
 
 import java.util.Arrays;
 import java.util.BitSet;
@@ -221,6 +222,11 @@ public final class HiveUtils {
 
     public static boolean isStructOI(@Nonnull final ObjectInspector oi) {
         return oi.getCategory() == Category.STRUCT;
+    }
+
+    public static boolean isVoidOI(@Nonnull final ObjectInspector oi) {
+        String typeName = oi.getTypeName();
+        return VOID_TYPE_NAME.equals(typeName);
     }
 
     public static boolean isStringOI(@Nonnull final ObjectInspector oi) {

--- a/core/src/main/java/hivemall/utils/io/BoundedInputStream.java
+++ b/core/src/main/java/hivemall/utils/io/BoundedInputStream.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.utils.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Input stream which only supplies bytes up to a certain length
+ * Implementation is based on BoundedInputStream in Apache Commons IO
+ * https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/input/BoundedInputStream.html
+ */
+public final class BoundedInputStream extends InputStream {
+    private static final int EOF = -1;
+
+    private final InputStream is;
+    private final long max;
+    private long pos = 0L;
+    private long mark = EOF;
+
+    public BoundedInputStream(final InputStream is) {
+        this(is, EOF); // wrapped, but unlimited input stream
+    }
+
+    public BoundedInputStream(final InputStream is, final long size) {
+        this.is = is;
+        this.max = size;
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (max >= 0 && pos >= max) {
+            return EOF;
+        }
+
+        int result = is.read();
+        this.pos += 1;
+
+        return result;
+    }
+
+    @Override
+    public int read(final byte[] b) throws IOException {
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (max >= 0 && pos >= max) {
+            return EOF;
+        }
+
+        long maxRead = max >= 0 ? Math.min(len, max - pos) : len;
+        int bytesRead = is.read(b, off, (int) maxRead);
+        if (bytesRead == EOF) {
+            return EOF;
+        }
+        this.pos += bytesRead;
+
+        return bytesRead;
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long toSkip = max >= 0 ? Math.min(n, max - pos) : n;
+        long skippedBytes = is.skip(toSkip);
+        this.pos += skippedBytes;
+        return skippedBytes;
+    }
+
+    @Override
+    public int available() throws IOException {
+        if (max >= 0 && pos >= max) {
+            return 0;
+        }
+        return is.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+        is.close();
+    }
+
+    @Override
+    public synchronized void reset() throws IOException {
+        is.reset();
+        this.pos = mark;
+    }
+
+    @Override
+    public synchronized void mark(int readlimit) {
+        is.mark(readlimit);
+        this.mark = pos;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return is.markSupported();
+    }
+
+}

--- a/core/src/main/java/hivemall/utils/io/HttpUtils.java
+++ b/core/src/main/java/hivemall/utils/io/HttpUtils.java
@@ -40,7 +40,7 @@ public final class HttpUtils {
 
     @Nonnull
     public static InputStream getLimitedInputStream(@Nonnull HttpURLConnection conn,
-            @Nonnegative long size) throws IOException {
+            @Nonnegative long size) throws NullPointerException, IOException {
         InputStream is = conn.getInputStream();
         is = new LimitedInputStream(is, size);
         return is;

--- a/core/src/main/java/hivemall/utils/io/HttpUtils.java
+++ b/core/src/main/java/hivemall/utils/io/HttpUtils.java
@@ -39,10 +39,10 @@ public final class HttpUtils {
     }
 
     @Nonnull
-    public static InputStream getBoundedInputStream(@Nonnull HttpURLConnection conn,
+    public static InputStream getLimitedInputStream(@Nonnull HttpURLConnection conn,
             @Nonnegative long size) throws IOException {
         InputStream is = conn.getInputStream();
-        is = new BoundedInputStream(is, size);
+        is = new LimitedInputStream(is, size);
         return is;
     }
 }

--- a/core/src/main/java/hivemall/utils/io/HttpUtils.java
+++ b/core/src/main/java/hivemall/utils/io/HttpUtils.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.utils.io;
+
+import javax.annotation.Nonnull;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public final class HttpUtils {
+    private HttpUtils() {}
+
+    @Nonnull
+    public static HttpURLConnection getHttpURLConnection(@Nonnull String urlStr)
+            throws IllegalArgumentException, IOException {
+        if (!urlStr.startsWith("http://") && !urlStr.startsWith("https://")) {
+            throw new IllegalArgumentException("Unexpected url: " + urlStr);
+        }
+        URL url = new URL(urlStr);
+        return (HttpURLConnection) url.openConnection();
+    }
+}

--- a/core/src/main/java/hivemall/utils/io/HttpUtils.java
+++ b/core/src/main/java/hivemall/utils/io/HttpUtils.java
@@ -18,8 +18,6 @@
  */
 package hivemall.utils.io;
 
-import org.apache.commons.io.input.BoundedInputStream;
-
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import java.io.IOException;

--- a/core/src/main/java/hivemall/utils/io/HttpUtils.java
+++ b/core/src/main/java/hivemall/utils/io/HttpUtils.java
@@ -18,8 +18,12 @@
  */
 package hivemall.utils.io;
 
+import org.apache.commons.io.input.BoundedInputStream;
+
+import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
@@ -34,5 +38,12 @@ public final class HttpUtils {
         }
         URL url = new URL(urlStr);
         return (HttpURLConnection) url.openConnection();
+    }
+
+    @Nonnull
+    public static InputStream getBoundedInputStream(@Nonnull HttpURLConnection conn, @Nonnegative long size) throws IOException {
+        InputStream is = conn.getInputStream();
+        is = new BoundedInputStream(is, size);
+        return is;
     }
 }

--- a/core/src/main/java/hivemall/utils/io/HttpUtils.java
+++ b/core/src/main/java/hivemall/utils/io/HttpUtils.java
@@ -41,7 +41,8 @@ public final class HttpUtils {
     }
 
     @Nonnull
-    public static InputStream getBoundedInputStream(@Nonnull HttpURLConnection conn, @Nonnegative long size) throws IOException {
+    public static InputStream getBoundedInputStream(@Nonnull HttpURLConnection conn,
+            @Nonnegative long size) throws IOException {
         InputStream is = conn.getInputStream();
         is = new BoundedInputStream(is, size);
         return is;

--- a/core/src/main/java/hivemall/utils/io/IOUtils.java
+++ b/core/src/main/java/hivemall/utils/io/IOUtils.java
@@ -33,6 +33,8 @@ import java.io.InputStreamReader;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
+import java.io.PushbackInputStream;
+import java.util.zip.GZIPInputStream;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -127,6 +129,29 @@ public final class IOUtils {
         final int ch3 = in.read();
         final int ch4 = in.read();
         return ((ch1 << 24) + (ch2 << 16) + (ch3 << 8) + (ch4 << 0));
+    }
+
+    /**
+     * Look ahead InputStream and decompress it as GZIPInputStream if needed
+     *
+     * @link https://stackoverflow.com/a/4818946
+     */
+    public static InputStream decompressStream(final InputStream is) throws IOException {
+        final PushbackInputStream pb = new PushbackInputStream(is, 2);
+
+        // look ahead
+        int b1 = pb.read();
+        int b2 = pb.read();
+
+        // push back
+        pb.unread(b2);
+        pb.unread(b1);
+
+        if (((b2 << 8) | b1) == GZIPInputStream.GZIP_MAGIC) {
+            return new GZIPInputStream(pb);
+        } else {
+            return pb;
+        }
     }
 
     public static void writeChar(final char v, final OutputStream out) throws IOException {

--- a/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
+++ b/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
@@ -35,9 +35,9 @@ public class LimitedInputStream extends FilterInputStream {
     protected final long max;
     protected long pos = 0L;
 
-    public LimitedInputStream(final InputStream is, @Nonnegative final long size) {
-        super(is);
-        this.max = size;
+    public LimitedInputStream(final InputStream in, @Nonnegative final long maxSize) {
+        super(in);
+        this.max = maxSize;
     }
 
     protected void raiseError() throws IOException {
@@ -53,29 +53,29 @@ public class LimitedInputStream extends FilterInputStream {
 
     @Override
     public int read() throws IOException {
-        int result = super.read();
-        if (result != -1) {
+        int res = super.read();
+        if (res != -1) {
             proceed(1L);
         }
-        return result;
+        return res;
     }
 
     @Override
     public int read(byte[] b, int off, int len) throws IOException {
-        int bytesRead = super.read(b, off, len);
-        if (bytesRead > 0) {
-            proceed(bytesRead);
+        int res = super.read(b, off, len);
+        if (res > 0) {
+            proceed(res);
         }
-        return bytesRead;
+        return res;
     }
 
     @Override
     public long skip(long n) throws IOException {
-        long skippedBytes = super.skip(n);
-        if (skippedBytes > 0) {
-            proceed(skippedBytes);
+        long res = super.skip(n);
+        if (res > 0) {
+            proceed(res);
         }
-        return skippedBytes;
+        return res;
     }
 
     @Override

--- a/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
+++ b/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
@@ -18,6 +18,9 @@
  */
 package hivemall.utils.io;
 
+import hivemall.utils.lang.Preconditions;
+
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnegative;
 import java.io.FilterInputStream;
 import java.io.IOException;
@@ -34,8 +37,9 @@ public class LimitedInputStream extends FilterInputStream {
     protected final long max;
     protected long pos = 0L;
 
-    public LimitedInputStream(final InputStream in, @Nonnegative final long maxSize) {
+    public LimitedInputStream(@CheckForNull final InputStream in, @Nonnegative final long maxSize) {
         super(in);
+        Preconditions.checkNotNull(in, "Base input stream must not be null");
         this.max = maxSize;
     }
 

--- a/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
+++ b/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
@@ -80,13 +80,4 @@ public class LimitedInputStream extends FilterInputStream {
         }
         return res;
     }
-
-    @Override
-    public int available() throws IOException {
-        if (pos >= max) {
-            return 0;
-        }
-        return super.available();
-    }
-
 }

--- a/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
+++ b/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
@@ -29,21 +29,25 @@ import java.io.InputStream;
  * @link https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/input/BoundedInputStream.html
  * @link https://commons.apache.org/proper/commons-fileupload/apidocs/org/apache/commons/fileupload/util/LimitedInputStream.html
  */
-public final class LimitedInputStream extends InputStream {
+public class LimitedInputStream extends InputStream {
 
     private final InputStream is;
-    private final long max;
-    private long pos = 0L;
+    protected final long max;
+    protected long pos = 0L;
 
     public LimitedInputStream(final InputStream is, @Nonnegative final long size) {
         this.is = is;
         this.max = size;
     }
 
+    protected void raiseError() throws IOException {
+        throw new IOException("Exceeded maximum size of input stream: limit = " + max + " bytes, but pos = " + pos);
+    }
+
     private void proceed(@Nonnegative long bytes) throws IOException {
         this.pos += bytes;
         if (pos > max) {
-            throw new IOException("Exceeded maximum size of input stream [" + max + " bytes]");
+            raiseError();
         }
     }
 

--- a/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
+++ b/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
@@ -27,10 +27,12 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Input stream which is limited to a certain length.
- * Implementation is based on LimitedInputStream in Apache Commons FileUpload.
+ * Input stream which is limited to a certain length. Implementation is based on LimitedInputStream
+ * in Apache Commons FileUpload.
  *
- * @link https://commons.apache.org/proper/commons-fileupload/apidocs/org/apache/commons/fileupload/util/LimitedInputStream.html
+ * @link 
+ *       https://commons.apache.org/proper/commons-fileupload/apidocs/org/apache/commons/fileupload/util
+ *       /LimitedInputStream.html
  */
 public class LimitedInputStream extends FilterInputStream {
 
@@ -44,7 +46,8 @@ public class LimitedInputStream extends FilterInputStream {
     }
 
     protected void raiseError() throws IOException {
-        throw new IOException("Exceeded maximum size of input stream: limit = " + max + " bytes, but pos = " + pos);
+        throw new IOException("Exceeded maximum size of input stream: limit = " + max
+                + " bytes, but pos = " + pos);
     }
 
     private void proceed(@Nonnegative long bytes) throws IOException {

--- a/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
+++ b/core/src/main/java/hivemall/utils/io/LimitedInputStream.java
@@ -24,10 +24,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Input stream which is limited to a certain length
- * Implementation is based on BoundedInputStream in Apache Commons IO and LimitedInputStream in Apache Commons FileUpload
+ * Input stream which is limited to a certain length.
+ * Implementation is based on LimitedInputStream in Apache Commons FileUpload.
  *
- * @link https://commons.apache.org/proper/commons-io/javadocs/api-2.5/org/apache/commons/io/input/BoundedInputStream.html
  * @link https://commons.apache.org/proper/commons-fileupload/apidocs/org/apache/commons/fileupload/util/LimitedInputStream.html
  */
 public class LimitedInputStream extends FilterInputStream {

--- a/core/src/test/java/hivemall/utils/io/LimitedInputStreamTest.java
+++ b/core/src/test/java/hivemall/utils/io/LimitedInputStreamTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.utils.io;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.IOException;
+import java.io.Reader;
+
+public class LimitedInputStreamTest {
+
+    @Test
+    public void testExactSize() throws IOException {
+        String expected = "abcdef";
+        int len = expected.length();
+
+        InputStream is = new FastByteArrayInputStream(expected.getBytes());
+        LimitedInputStream isLimited = new LimitedInputStream(is, len);
+
+        Reader reader = new InputStreamReader(isLimited);
+        BufferedReader br = new BufferedReader(reader);
+
+        char[] buf = new char[len];
+        br.read(buf);
+
+        Assert.assertTrue(expected.equals(new String(buf)));
+    }
+
+    @Test
+    public void testLooseSize() throws IOException {
+        String expected = "abcdef";
+        int len = expected.length();
+
+        InputStream is = new FastByteArrayInputStream(expected.getBytes());
+        LimitedInputStream isLimited = new LimitedInputStream(is, len + 100); // large enough
+
+        Reader reader = new InputStreamReader(isLimited);
+        BufferedReader br = new BufferedReader(reader);
+
+        char[] buf = new char[len];
+        br.read(buf);
+
+        Assert.assertTrue(expected.equals(new String(buf)));
+    }
+
+    @Test(expected = IOException.class)
+    public void testExceed() throws IOException {
+        String expected = "abcdef";
+        int len = expected.length();
+
+        InputStream is = new FastByteArrayInputStream(expected.getBytes());
+        LimitedInputStream isLimited = new LimitedInputStream(is, len - 1); // not enough
+
+        Reader reader = new InputStreamReader(isLimited);
+        BufferedReader br = new BufferedReader(reader);
+
+        char[] buf = new char[len];
+        br.read(buf);
+    }
+
+}

--- a/core/src/test/java/hivemall/utils/io/LimitedInputStreamTest.java
+++ b/core/src/test/java/hivemall/utils/io/LimitedInputStreamTest.java
@@ -78,4 +78,9 @@ public class LimitedInputStreamTest {
         br.read(buf);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testNullInputStream() throws NullPointerException {
+        new LimitedInputStream(null, 100);
+    }
+
 }

--- a/docs/gitbook/misc/tokenizer.md
+++ b/docs/gitbook/misc/tokenizer.md
@@ -28,23 +28,28 @@ tokenize(text input, optional boolean toLowerCase = false)
 
 Hivemall-NLP module provides some Non-English Text tokenizer UDFs as follows.
 
-First of all, you need to issue the following DDLs to use the NLP module. Note NLP module is not included in [hivemall-with-dependencies.jar](https://github.com/myui/hivemall/releases).
+First of all, you need to issue the following DDLs to use the NLP module. Note NLP module is not included in `hivemall-with-dependencies.jar`.
 
-> add jar /tmp/[hivemall-nlp-xxx-with-dependencies.jar](https://github.com/myui/hivemall/releases);
+> add jar /path/to/hivemall-nlp-xxx-with-dependencies.jar;
 
-> source /tmp/[define-additional.hive](https://github.com/myui/hivemall/releases);
+> source /path/to/define-additional.hive;
 
 ## Japanese Tokenizer
 
 Japanese text tokenizer UDF uses [Kuromoji](https://github.com/atilika/kuromoji). 
 
 The signature of the UDF is as follows:
-```sql
-tokenize_ja(text input, optional const text mode = "normal", optional const array<string> stopWords, optional const array<string> stopTags)
-```
-_Caution: `tokenize_ja` is supported since Hivemall v0.4.1 and later._
 
-It's basic usage is as follows:
+```sql
+tokenize_ja(text input, optional const text mode = "normal", optional const array<string> stopWords, const array<string> stopTags, const array<string> userDict)
+```
+
+Note that the fifth argument `userDict` enables you to register user-defined dictionary in [Kuromoji official format](https://github.com/atilika/kuromoji/blob/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/resources/userdict.txt). If you have a large custom dictionary as an external file, the argument can also be `const string userDictURL` which indicates URL of the external file on somewhere like Amazon S3. 
+
+> #### Caution
+> `tokenize_ja` is supported since Hivemall v0.4.1, and the fifth argument is supported since v0.5-rc.1 and later.
+
+Its basic usage is as follows:
 ```sql
 select tokenize_ja("kuromojiを使った分かち書きのテストです。第二引数にはnormal/search/extendedを指定できます。デフォルトではnormalモードです。");
 ```
@@ -61,7 +66,7 @@ The signature of the UDF is as follows:
 tokenize_cn(string line, optional const array<string> stopWords)
 ```
 
-It's basic usage is as follows:
+Its basic usage is as follows:
 ```sql
 select tokenize_cn("Smartcn为Apache2.0协议的开源中文分词系统，Java语言编写，修改的中科院计算所ICTCLAS分词系统。");
 ```

--- a/docs/gitbook/misc/tokenizer.md
+++ b/docs/gitbook/misc/tokenizer.md
@@ -44,9 +44,7 @@ The signature of the UDF is as follows:
 tokenize_ja(text input, optional const text mode = "normal", optional const array<string> stopWords, const array<string> stopTags, const array<string> userDict)
 ```
 
-Note that the fifth argument `userDict` enables you to register user-defined dictionary in [Kuromoji official format](https://github.com/atilika/kuromoji/blob/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/resources/userdict.txt). If you have a large custom dictionary as an external file, the argument can also be `const string userDictURL` which indicates URL of the external file on somewhere like Amazon S3. 
-
-> #### Caution
+> #### Note
 > `tokenize_ja` is supported since Hivemall v0.4.1, and the fifth argument is supported since v0.5-rc.1 and later.
 
 Its basic usage is as follows:
@@ -54,6 +52,37 @@ Its basic usage is as follows:
 select tokenize_ja("kuromojiを使った分かち書きのテストです。第二引数にはnormal/search/extendedを指定できます。デフォルトではnormalモードです。");
 ```
 > ["kuromoji","使う","分かち書き","テスト","第","二","引数","normal","search","extended","指定","デフォルト","normal","モード"]
+
+In addition, the third and fourth argument respectively allow you to use your own list of stop words and stop tags. For example, the following query simply ignores "kuromoji" (as a stop word) and noun word "分かち書き" (as a stop tag):
+
+```sql
+select tokenize_ja("kuromojiを使った分かち書きのテストです。", "normal", array("kuromoji"), array("名詞-一般"));
+```
+
+> ["を","使う","た","の","テスト","です"]
+
+Moreover, the fifth argument `userDict` enables you to register a user-defined custom dictionary in [Kuromoji official format](https://github.com/atilika/kuromoji/blob/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/resources/userdict.txt):
+
+```sql
+select tokenize_ja("日本経済新聞＆関西国際空港", "normal", null, null, 
+                   array(
+                     "日本経済新聞,日本 経済 新聞,ニホン ケイザイ シンブン,カスタム名詞", 
+                     "関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,テスト名詞"
+                   ));
+```
+
+> ["日本","経済","新聞","関西","国際","空港"]
+
+Note that you can pass `null` to each of the third and fourth argument to explicitly use Kuromoji's default stop words and stop tags. 
+
+If you have a large custom dictionary as an external file, `userDict` can also be `const string userDictURL` which indicates URL of the external file on somewhere like Amazon S3:
+
+```sql
+select tokenize_ja("日本経済新聞＆関西国際空港", "normal", null, null,
+                   "https://raw.githubusercontent.com/atilika/kuromoji/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/resources/userdict.txt");
+```
+
+> ["日本","経済","新聞","関西","国際","空港"]
 
 For detailed APIs, please refer Javadoc of [JapaneseAnalyzer](https://lucene.apache.org/core/5_3_1/analyzers-kuromoji/org/apache/lucene/analysis/ja/JapaneseAnalyzer.html) as well.
 

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -234,7 +234,7 @@ public final class KuromojiUDF extends GenericUDF {
         final HttpURLConnection conn;
         try {
             conn = HttpUtils.getHttpURLConnection(userDictURL);
-        } catch (Throwable e) {
+        } catch (Exception e) {
             throw new UDFArgumentException("Failed to create HTTP connection to the URL: " + e);
         }
 
@@ -247,7 +247,7 @@ public final class KuromojiUDF extends GenericUDF {
         final int responseCode;
         try {
             responseCode = conn.getResponseCode();
-        } catch (Throwable e) {
+        } catch (IOException e) {
             throw new UDFArgumentException("Failed to get response code: " + e);
         }
         if (responseCode != 200) {
@@ -257,7 +257,7 @@ public final class KuromojiUDF extends GenericUDF {
         final InputStream is;
         try {
             is = IOUtils.decompressStream(HttpUtils.getLimitedInputStream(conn, MAX_INPUT_STREAM_SIZE));
-        } catch (Throwable e) {
+        } catch (IOException e) {
             throw new UDFArgumentException("Failed to get input stream from the connection: " + e);
         }
 

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -19,7 +19,6 @@
 package hivemall.nlp.tokenizer;
 
 import hivemall.utils.hadoop.HiveUtils;
-import hivemall.utils.io.FastByteArrayInputStream;
 import hivemall.utils.io.IOUtils;
 import hivemall.utils.io.HttpUtils;
 
@@ -27,6 +26,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.io.StringReader;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -217,8 +217,7 @@ public final class KuromojiUDF extends GenericUDF {
             builder.append(row);
             builder.append("\n");
         }
-        InputStream is = new FastByteArrayInputStream(builder.toString().getBytes());
-        final Reader reader = new InputStreamReader(is);
+        final Reader reader = new StringReader(builder.toString());
         try {
             return UserDictionary.open(reader); // return null if empty
         } catch (Throwable e) {

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -239,6 +239,16 @@ public final class KuromojiUDF extends GenericUDF {
         conn.setConnectTimeout(CONNECT_TIMEOUT_MS); // throw exception from connect()
         conn.setReadTimeout(READ_TIMEOUT_MS); // throw exception from getXXX() methods
 
+        final int responseCode;
+        try {
+            responseCode = conn.getResponseCode();
+        } catch (Throwable e) {
+            throw new UDFArgumentException("Failed to get response code: " + e);
+        }
+        if (responseCode != 200) {
+            throw new UDFArgumentException("God invalid response code: " + responseCode);
+        }
+
         final String contentType = conn.getContentType();
         boolean textContent = contentType.startsWith("text/plain");
         boolean binaryContent = contentType.startsWith("application/octet-stream");

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -267,7 +267,7 @@ public final class KuromojiUDF extends GenericUDF {
 
         InputStream is;
         try {
-            is = HttpUtils.getBoundedInputStream(conn, MAX_INPUT_STREAM_SIZE);
+            is = HttpUtils.getLimitedInputStream(conn, MAX_INPUT_STREAM_SIZE);
             if ((textContent && "gzip".equals(conn.getContentEncoding())) || binaryContent) {
                 is = new GZIPInputStream(is);
             }

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -215,7 +215,7 @@ public final class KuromojiUDF extends GenericUDF {
         StringBuilder builder = new StringBuilder();
         for (String row : userDictArray) {
             builder.append(row);
-            builder.append("\r\n");
+            builder.append(System.getProperty("line.separator"));
         }
         InputStream is = new FastByteArrayInputStream(builder.toString().getBytes());
         final Reader reader = new InputStreamReader(is);

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -20,13 +20,13 @@ package hivemall.nlp.tokenizer;
 
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.io.IOUtils;
+import hivemall.utils.io.HttpUtils;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.Reader;
 import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -195,9 +195,7 @@ public final class KuromojiUDF extends GenericUDF {
         }
 
         try {
-            URL url = new URL(userDictURL);
-
-            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            HttpURLConnection conn = HttpUtils.getHttpURLConnection(userDictURL);
             conn.setRequestProperty("Accept-Encoding", "gzip");
             conn.setConnectTimeout(CONNECT_TIMEOUT_MS); // throw exception from connect()
             conn.setReadTimeout(READ_TIMEOUT_MS); // throw exception from getXXX() methods

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
@@ -137,7 +138,7 @@ public final class KuromojiUDF extends GenericUDF {
     }
 
     @Nonnull
-    private static CharArraySet stopWords(@Nonnull final String[] array)
+    private static CharArraySet stopWords(@Nullable final String[] array)
             throws UDFArgumentException {
         if (array == null) {
             return JapaneseAnalyzer.getDefaultStopSet();

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -257,7 +257,7 @@ public final class KuromojiUDF extends GenericUDF {
         final InputStream is;
         try {
             is = IOUtils.decompressStream(HttpUtils.getLimitedInputStream(conn, MAX_INPUT_STREAM_SIZE));
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new UDFArgumentException("Failed to get input stream from the connection: " + e);
         }
 

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -194,7 +194,8 @@ public final class KuromojiUDF extends GenericUDF {
         } else if (HiveUtils.isConstString(oi)) {
             return userDictionary(HiveUtils.getConstString(oi));
         } else {
-            throw new UDFArgumentException("User dictionary MUST be given as an array of constant string or constant string (URL)");
+            throw new UDFArgumentException(
+                "User dictionary MUST be given as an array of constant string or constant string (URL)");
         }
     }
 
@@ -215,7 +216,8 @@ public final class KuromojiUDF extends GenericUDF {
         try {
             return UserDictionary.open(reader); // return null if empty
         } catch (Throwable e) {
-            throw new UDFArgumentException("Failed to create user dictionary based on the given array<string>: " + e);
+            throw new UDFArgumentException(
+                "Failed to create user dictionary based on the given array<string>: " + e);
         }
     }
 
@@ -253,7 +255,8 @@ public final class KuromojiUDF extends GenericUDF {
         boolean textContent = contentType.startsWith("text/plain");
         boolean binaryContent = contentType.startsWith("application/octet-stream");
         if (!textContent && !binaryContent) {
-            throw new UDFArgumentException("User dictionary URL indicates unexpected content type: " + contentType);
+            throw new UDFArgumentException(
+                "User dictionary URL indicates unexpected content type: " + contentType);
         }
 
         InputStream is;
@@ -263,7 +266,8 @@ public final class KuromojiUDF extends GenericUDF {
                 is = new GZIPInputStream(is);
             }
         } catch (ZipException e) { // HTTP connection indicates a non-GZIP binary file
-            throw new UDFArgumentException("User dictionary URL MUST indicate plain text or GZIP file: " + e);
+            throw new UDFArgumentException(
+                "User dictionary URL MUST indicate plain text or GZIP file: " + e);
         } catch (Throwable e) {
             throw new UDFArgumentException("Failed to get input stream from the connection: " + e);
         }

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -64,8 +64,8 @@ import org.apache.lucene.analysis.util.CharArraySet;
 @UDFType(deterministic = true, stateful = false)
 public final class KuromojiUDF extends GenericUDF {
     private static final int CONNECT_TIMEOUT_MS = 10000;
-    private static final int READ_TIMEOUT_MS = 30000;
-    private static final long MAX_INPUT_STREAM_SIZE = 1000000L; // ~1MB
+    private static final int READ_TIMEOUT_MS = 60000;
+    private static final long MAX_INPUT_STREAM_SIZE = 32L * 1024L * 1024L; // ~32MB
 
     private Mode _mode;
     private CharArraySet _stopWords;

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -254,7 +254,7 @@ public final class KuromojiUDF extends GenericUDF {
             throw new UDFArgumentException("Failed to get response code: " + e);
         }
         if (responseCode != 200) {
-            throw new UDFArgumentException("God invalid response code: " + responseCode);
+            throw new UDFArgumentException("Got invalid response code: " + responseCode);
         }
 
         final String contentType = conn.getContentType();

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -34,8 +34,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.zip.GZIPInputStream;
-import java.util.zip.ZipException;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -154,6 +154,9 @@ public final class KuromojiUDF extends GenericUDF {
     @Nonnull
     private static CharArraySet stopWords(@Nonnull final ObjectInspector oi)
             throws UDFArgumentException {
+        if (HiveUtils.isVoidOI(oi)) {
+            return JapaneseAnalyzer.getDefaultStopSet();
+        }
         final String[] array = HiveUtils.getConstStringArray(oi);
         if (array == null) {
             return JapaneseAnalyzer.getDefaultStopSet();
@@ -168,6 +171,9 @@ public final class KuromojiUDF extends GenericUDF {
     @Nonnull
     private static Set<String> stopTags(@Nonnull final ObjectInspector oi)
             throws UDFArgumentException {
+        if (HiveUtils.isVoidOI(oi)) {
+            return JapaneseAnalyzer.getDefaultStopTags();
+        }
         final String[] array = HiveUtils.getConstStringArray(oi);
         if (array == null) {
             return JapaneseAnalyzer.getDefaultStopTags();

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -256,7 +256,8 @@ public final class KuromojiUDF extends GenericUDF {
 
         final InputStream is;
         try {
-            is = IOUtils.decompressStream(HttpUtils.getLimitedInputStream(conn, MAX_INPUT_STREAM_SIZE));
+            is = IOUtils.decompressStream(HttpUtils.getLimitedInputStream(conn,
+                MAX_INPUT_STREAM_SIZE));
         } catch (Exception e) {
             throw new UDFArgumentException("Failed to get input stream from the connection: " + e);
         }

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -19,6 +19,7 @@
 package hivemall.nlp.tokenizer;
 
 import hivemall.utils.hadoop.HiveUtils;
+import hivemall.utils.io.FastByteArrayInputStream;
 import hivemall.utils.io.IOUtils;
 import hivemall.utils.io.HttpUtils;
 
@@ -26,7 +27,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.Reader;
-import java.io.ByteArrayInputStream;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -217,7 +217,7 @@ public final class KuromojiUDF extends GenericUDF {
             builder.append(row);
             builder.append("\r\n");
         }
-        InputStream is = new ByteArrayInputStream(builder.toString().getBytes());
+        InputStream is = new FastByteArrayInputStream(builder.toString().getBytes());
         final Reader reader = new InputStreamReader(is);
         try {
             return UserDictionary.open(reader); // return null if empty

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -63,6 +63,8 @@ import sun.net.www.content.text.PlainTextInputStream;
                 + " - returns tokenized strings in array<string>")
 @UDFType(deterministic = true, stateful = false)
 public final class KuromojiUDF extends GenericUDF {
+    private static final int CONNECT_TIMEOUT_MS = 10000;
+    private static final int READ_TIMEOUT_MS = 30000;
 
     private Mode _mode;
     private String[] _stopWordsArray;
@@ -192,8 +194,11 @@ public final class KuromojiUDF extends GenericUDF {
 
         try {
             URL url = new URL(userDictURL);
+
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestProperty("Accept-Encoding", "gzip");
+            conn.setConnectTimeout(CONNECT_TIMEOUT_MS); // throw exception from connect()
+            conn.setReadTimeout(READ_TIMEOUT_MS); // throw exception from getXXX() methods
 
             if (conn.getContent(new Class[] {PlainTextInputStream.class}) == null) {
                 throw new UDFArgumentException("User dictionary URL MUST points plain text");

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -234,7 +234,7 @@ public final class KuromojiUDF extends GenericUDF {
         final HttpURLConnection conn;
         try {
             conn = HttpUtils.getHttpURLConnection(userDictURL);
-        } catch (Exception e) {
+        } catch (IllegalArgumentException | IOException e) {
             throw new UDFArgumentException("Failed to create HTTP connection to the URL: " + e);
         }
 
@@ -258,7 +258,7 @@ public final class KuromojiUDF extends GenericUDF {
         try {
             is = IOUtils.decompressStream(HttpUtils.getLimitedInputStream(conn,
                 MAX_INPUT_STREAM_SIZE));
-        } catch (Exception e) {
+        } catch (NullPointerException | IOException e) {
             throw new UDFArgumentException("Failed to get input stream from the connection: " + e);
         }
 

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -199,11 +199,9 @@ public final class KuromojiUDF extends GenericUDF {
                 throw new UDFArgumentException("User dictionary URL MUST points plain text");
             }
 
-            final InputStream stream;
+            InputStream stream = conn.getInputStream();
             if ("gzip".equals(conn.getContentEncoding())) {
-                stream = new GZIPInputStream(conn.getInputStream());
-            } else {
-                stream = conn.getInputStream();
+                stream = new GZIPInputStream(stream);
             }
 
             Reader reader = new InputStreamReader(stream);

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -38,6 +38,7 @@ import java.util.zip.GZIPInputStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.commons.io.input.BoundedInputStream;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -65,6 +66,7 @@ import sun.net.www.content.text.PlainTextInputStream;
 public final class KuromojiUDF extends GenericUDF {
     private static final int CONNECT_TIMEOUT_MS = 10000;
     private static final int READ_TIMEOUT_MS = 30000;
+    private static final long MAX_INPUT_STREAM_SIZE = 1000000L; // ~1MB
 
     private Mode _mode;
     private String[] _stopWordsArray;
@@ -205,6 +207,7 @@ public final class KuromojiUDF extends GenericUDF {
             }
 
             InputStream stream = conn.getInputStream();
+            stream = new BoundedInputStream(stream, MAX_INPUT_STREAM_SIZE);
             if ("gzip".equals(conn.getContentEncoding())) {
                 stream = new GZIPInputStream(stream);
             }

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -215,7 +215,7 @@ public final class KuromojiUDF extends GenericUDF {
         StringBuilder builder = new StringBuilder();
         for (String row : userDictArray) {
             builder.append(row);
-            builder.append(System.getProperty("line.separator"));
+            builder.append("\n");
         }
         InputStream is = new FastByteArrayInputStream(builder.toString().getBytes());
         final Reader reader = new InputStreamReader(is);

--- a/nlp/src/test/java/hivemall/nlp/tokenizer/KuromojiUDFTest.java
+++ b/nlp/src/test/java/hivemall/nlp/tokenizer/KuromojiUDFTest.java
@@ -337,7 +337,9 @@ public class KuromojiUDFTest {
         // userDictUrl (Kuromoji official sample user defined dict on GitHub)
         // e.g., "日本経済新聞" will be "日本", "経済", and "新聞"
         argOIs[4] = PrimitiveObjectInspectorFactory.getPrimitiveWritableConstantObjectInspector(
-            stringType, new Text("https://raw.githubusercontent.com/atilika/kuromoji/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/resources/userdict.txt"));
+            stringType,
+            new Text(
+                "https://raw.githubusercontent.com/atilika/kuromoji/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/resources/userdict.txt"));
         udf.initialize(argOIs);
 
         DeferredObject[] args = new DeferredObject[1];

--- a/nlp/src/test/java/hivemall/nlp/tokenizer/KuromojiUDFTest.java
+++ b/nlp/src/test/java/hivemall/nlp/tokenizer/KuromojiUDFTest.java
@@ -260,6 +260,7 @@ public class KuromojiUDFTest {
         // userDictArray (from https://raw.githubusercontent.com/atilika/kuromoji/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/resources/userdict.txt)
         List<String> userDict = new ArrayList<String>();
         userDict.add("日本経済新聞,日本 経済 新聞,ニホン ケイザイ シンブン,カスタム名詞");
+        userDict.add("関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,テスト名詞");
         argOIs[4] = ObjectInspectorFactory.getStandardConstantListObjectInspector(
             PrimitiveObjectInspectorFactory.writableStringObjectInspector, userDict);
         udf.initialize(argOIs);

--- a/nlp/src/test/java/hivemall/nlp/tokenizer/KuromojiUDFTest.java
+++ b/nlp/src/test/java/hivemall/nlp/tokenizer/KuromojiUDFTest.java
@@ -260,7 +260,7 @@ public class KuromojiUDFTest {
         // userDictArray (from https://raw.githubusercontent.com/atilika/kuromoji/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/resources/userdict.txt)
         List<String> userDict = new ArrayList<String>();
         userDict.add("日本経済新聞,日本 経済 新聞,ニホン ケイザイ シンブン,カスタム名詞");
-        argOIs[4] = argOIs[2] = ObjectInspectorFactory.getStandardConstantListObjectInspector(
+        argOIs[4] = ObjectInspectorFactory.getStandardConstantListObjectInspector(
             PrimitiveObjectInspectorFactory.writableStringObjectInspector, userDict);
         udf.initialize(argOIs);
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

- Add a new argument to `tokenize_ja` which enables users to register user-defined dictionary
  - Value can be either `const array<string>` (for array of custom definitions) or `const string` (for URL pointing an external dictionary file)
  - Users need to follow [Kuromoji official user dictionary format](https://github.com/atilika/kuromoji/blob/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/resources/userdict.txt) as `<word>,<result>,<read>,<class>`
- Update document and refactor accordingly

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-130

## How was this patch tested?

Manually tested both on local and EMR with the Kuromoji official sample file:

```
hive> select
    >   tokenize_ja("日本経済新聞", "normal"),
    >   tokenize_ja("日本経済新聞", "normal", array(), array(), "https://raw.githubusercontent.com/atilika/kuromoji/909fd6b32bf4e9dc86b7599de5c9b50ca8f004a1/kuromoji-core/src/test/res/userdict.txt"),
    >   tokenize_ja("日本経済新聞", "normal", array(), array(), array("日本経済新聞,日本 経済 新聞,ニホン ケイザイ シンブン,カスタム名詞", "関西国際空港,関西 国際 空港,カンサイ コクサイ クウコウ,テスト名詞"))
    > ;
OK
_c0     _c1     _c2
["日本経済新聞"]        ["日本","経済","新聞"]  ["日本","経済","新聞"]
Time taken: 2.094 seconds, Fetched: 1 row(s)
```

## How to use this feature?

As shown above.

## Checklist

- [x] Did you apply source code formatter, i.e., `mvn formatter:format`, for your commit?