### PR TITLE
[HIVEMALL-142] Implement SingularizeUDF

### DIFF
--- a/core/src/main/java/hivemall/tools/text/SingularizeUDF.java
+++ b/core/src/main/java/hivemall/tools/text/SingularizeUDF.java
@@ -44,7 +44,7 @@ import hivemall.utils.lang.StringUtils;
 @UDFType(deterministic = true, stateful = false)
 public final class SingularizeUDF extends UDF {
 
-    // sorted by a ascending (i.e., alphabetical) order for binary search
+    // sorted by an ascending (i.e., alphabetical) order for binary search
     // plural preposition to detect compound words like "plural-preposition-something"
     private static final String[] prepositions = new String[] {"about", "above", "across", "after",
             "among", "around", "at", "athwart", "before", "behind", "below", "beneath", "beside",
@@ -109,7 +109,7 @@ public final class SingularizeUDF extends UDF {
     }
 
     private static final List<String> rules = Arrays.asList(
-        // regexp1, replacement1, regexp2, regexp2, ...
+        // regexp1, replacement1, regexp2, replacement2, ...
         "(quiz)zes$", "$1", "(matr)ices$", "$1ix", "(vert|ind)ices$", "$1ex", "^(ox)en", "$1",
         "(alias|status)$", "$1", "(alias|status)es$", "$1", "(octop|vir)us$", "$1us",
         "(octop|vir)i$", "$1us", "(cris|ax|test)es$", "$1is", "(cris|ax|test)is$", "$1is",

--- a/core/src/main/java/hivemall/tools/text/SingularizeUDF.java
+++ b/core/src/main/java/hivemall/tools/text/SingularizeUDF.java
@@ -143,7 +143,7 @@ public final class SingularizeUDF extends UDF {
 
             if ((chunks.size() > 1) && (Arrays.binarySearch(prepositions, chunks.get(1)) >= 0)) {
                 String head = chunks.remove(0);
-                return singularize(head) + "-" + StringUtils.concat(chunks, "-");
+                return singularize(head) + "-" + StringUtils.join(chunks, "-");
             }
         }
 

--- a/core/src/main/java/hivemall/tools/text/SingularizeUDF.java
+++ b/core/src/main/java/hivemall/tools/text/SingularizeUDF.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.tools.text;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.hive.ql.udf.UDFType;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import hivemall.utils.lang.StringUtils;
+
+/**
+ * @link
+ *       https://github.com/sundrio/sundrio/blob/95c2b11f7b842bdaa04f61e8e338aea60fb38f70/codegen/src
+ *       /main/java/io/sundr/codegen/functions/Singularize.java
+ * @link https://github.com/clips/pattern/blob/
+ *       3eef00481a4555331cf9a099308910d977f6fc22/pattern/text/en/inflect.py#L445-L623
+ */
+@Description(name = "singularize",
+        value = "_FUNC_(string word) - Returns singular form of a given English word")
+@UDFType(deterministic = true, stateful = false)
+public final class SingularizeUDF extends UDF {
+
+    // sorted by a ascending (i.e., alphabetical) order for binary search
+    // plural preposition to detect compound words like "plural-preposition-something"
+    private static final String[] prepositions = new String[] {"about", "above", "across", "after",
+            "among", "around", "at", "athwart", "before", "behind", "below", "beneath", "beside",
+            "besides", "between", "betwixt", "beyond", "but", "by", "during", "except", "for",
+            "from", "in", "into", "near", "of", "off", "on", "onto", "out", "over", "since",
+            "till", "to", "under", "until", "unto", "upon", "with"};
+    // uninfected or uncountable words
+    private static final String[] unchanged = new String[] {"advice", "bison", "bread", "bream",
+            "breeches", "britches", "butter", "carp", "chassis", "cheese", "christmas", "clippers",
+            "cod", "contretemps", "corps", "debris", "diabetes", "djinn", "eland", "electricity",
+            "elk", "equipment", "flounder", "fruit", "furniture", "gallows", "garbage", "georgia",
+            "graffiti", "gravel", "happiness", "headquarters", "herpes", "high-jinks", "homework",
+            "information", "innings", "jackanapes", "ketchup", "knowledge", "love", "luggage",
+            "mackerel", "mathematics", "mayonnaise", "measles", "meat", "mews", "mumps", "mustard",
+            "news", "news", "pincers", "pliers", "proceedings", "progress", "rabies", "research",
+            "rice", "salmon", "sand", "scissors", "series", "shears", "software", "species",
+            "swine", "swiss", "trout", "tuna", "understanding", "water", "whiting", "wildebeest"};
+
+    private static final Map<String, String> irregular = new HashMap<String, String>();
+    static {
+        irregular.put("atlantes", "atlas");
+        irregular.put("atlases", "atlas");
+        irregular.put("axes", "axe");
+        irregular.put("beeves", "beef");
+        irregular.put("brethren", "brother");
+        irregular.put("children", "child");
+        irregular.put("corpora", "corpus");
+        irregular.put("corpuses", "corpus");
+        irregular.put("ephemerides", "ephemeris");
+        irregular.put("feet", "foot");
+        irregular.put("ganglia", "ganglion");
+        irregular.put("geese", "goose");
+        irregular.put("genera", "genus");
+        irregular.put("genii", "genie");
+        irregular.put("graffiti", "graffito");
+        irregular.put("helves", "helve");
+        irregular.put("kine", "cow");
+        irregular.put("leaves", "leaf");
+        irregular.put("loaves", "loaf");
+        irregular.put("men", "man");
+        irregular.put("mongooses", "mongoose");
+        irregular.put("monies", "money");
+        irregular.put("moves", "move");
+        irregular.put("mythoi", "mythos");
+        irregular.put("numena", "numen");
+        irregular.put("occipita", "occiput");
+        irregular.put("octopodes", "octopus");
+        irregular.put("opera", "opus");
+        irregular.put("opuses", "opus");
+        irregular.put("our", "my");
+        irregular.put("oxen", "ox");
+        irregular.put("penes", "penis");
+        irregular.put("penises", "penis");
+        irregular.put("people", "person");
+        irregular.put("sexes", "sex");
+        irregular.put("soliloquies", "soliloquy");
+        irregular.put("teeth", "tooth");
+        irregular.put("testes", "testis");
+        irregular.put("trilbys", "trilby");
+        irregular.put("turves", "turf");
+        irregular.put("zoa", "zoon");
+    }
+
+    private static final List<String> rules = Arrays.asList(
+        // regexp1, replacement1, regexp2, regexp2, ...
+        "(quiz)zes$", "$1", "(matr)ices$", "$1ix", "(vert|ind)ices$", "$1ex", "^(ox)en", "$1",
+        "(alias|status)$", "$1", "(alias|status)es$", "$1", "(octop|vir)us$", "$1us",
+        "(octop|vir)i$", "$1us", "(cris|ax|test)es$", "$1is", "(cris|ax|test)is$", "$1is",
+        "(shoe)s$", "$1", "(o)es$", "$1", "(bus)es$", "$1", "([m|l])ice$", "$1ouse",
+        "(x|ch|ss|sh)es$", "$1", "(m)ovies$", "$1ovie", "(s)eries$", "$1eries",
+        "([^aeiouy]|qu)ies$", "$1y", "([lr])ves$", "$1f", "(tive)s$", "$1", "(hive)s$", "$1",
+        "([^f])ves$", "$1fe", "(^analy)sis$", "$1sis", "(^analy)ses$", "$1sis",
+        "((a)naly|(b)a|(d)iagno|(p)arenthe|(p)rogno|(s)ynop|(t)he)ses$", "$1$2sis", "([ti])a$",
+        "$1um", "(n)ews$", "$1ews", "(s|si|u)s$", "$1s", "s$", "");
+
+    public String evaluate(String word) {
+        return singularize(word);
+    }
+
+    private String singularize(String word) {
+        if (word == null) {
+            return null;
+        }
+
+        if (word.isEmpty()) {
+            return word;
+        }
+
+        if (Arrays.binarySearch(unchanged, word) >= 0) {
+            return word;
+        }
+
+        if (word.contains("-")) { // compound words (e.g., mothers-in-law)
+            final List<String> chunks = new ArrayList<String>();
+            chunks.addAll(Arrays.asList(word.split("-")));
+
+            if ((chunks.size() > 1) && (Arrays.binarySearch(prepositions, chunks.get(1)) >= 0)) {
+                String head = chunks.remove(0);
+                return singularize(head) + "-" + StringUtils.concat(chunks, "-");
+            }
+        }
+
+        if (word.endsWith("'")) { // dogs' => dog's
+            return singularize(word.substring(0, word.length() - 1)) + "'s";
+        }
+
+        if (irregular.containsKey(word)) {
+            return irregular.get(word);
+        }
+
+        for (int i = 0, n = rules.size(); i < n; i += 2) {
+            Pattern pattern = Pattern.compile(rules.get(i), Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(word);
+            if (matcher.find()) {
+                return matcher.replaceAll(rules.get(i + 1));
+            }
+        }
+
+        return word;
+    }
+
+}

--- a/core/src/main/java/hivemall/utils/lang/StringUtils.java
+++ b/core/src/main/java/hivemall/utils/lang/StringUtils.java
@@ -185,16 +185,14 @@ public final class StringUtils {
     public static String join(@Nonnull final List<String> list, @Nonnull final String sep) {
         final StringBuilder buf = new StringBuilder(128);
         for (int i = 0, size = list.size(); i < size; i++) {
-            final String s = list.get(i);
-            if (s == null) {
-                continue;
-            }
-
             if (i > 0) { // append separator before each element, except for the head element
                 buf.append(sep);
             }
 
-            buf.append(s);
+            final String s = list.get(i);
+            if (s != null) {
+                buf.append(s);
+            }
         }
         return buf.toString();
     }

--- a/core/src/main/java/hivemall/utils/lang/StringUtils.java
+++ b/core/src/main/java/hivemall/utils/lang/StringUtils.java
@@ -53,7 +53,7 @@ public final class StringUtils {
 
     /**
      * Checks whether the String a valid Java number. this code is ported from jakarta commons lang.
-     * 
+     *
      * @link http://jakarta.apache.org/commons/lang/apidocs/org/apache/commons/lang
      *       /math/NumberUtils.html
      */
@@ -97,7 +97,7 @@ public final class StringUtils {
 
             } else if (chars[i] == '.') {
                 if (hasDecPoint || hasExp) {
-                    // two decimal points or dec in exponent   
+                    // two decimal points or dec in exponent
                     return false;
                 }
                 hasDecPoint = true;
@@ -178,6 +178,23 @@ public final class StringUtils {
             }
             buf.append(s);
             buf.append(sep);
+        }
+        return buf.toString();
+    }
+
+    public static String join(@Nonnull final List<String> list, @Nonnull final String sep) {
+        final StringBuilder buf = new StringBuilder(128);
+        for (int i = 0, size = list.size(); i < size; i++) {
+            final String s = list.get(i);
+            if (s == null) {
+                continue;
+            }
+
+            if (i > 0) { // append separator before each element, except for the head element
+                buf.append(sep);
+            }
+
+            buf.append(s);
         }
         return buf.toString();
     }

--- a/core/src/test/java/hivemall/tools/text/SingularizeUDFTest.java
+++ b/core/src/test/java/hivemall/tools/text/SingularizeUDFTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.tools.text;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SingularizeUDFTest {
+
+    private SingularizeUDF udf;
+
+    @Before
+    public void setUp() {
+        this.udf = new SingularizeUDF();
+    }
+
+    @Test
+    public void testNull() {
+        Assert.assertEquals(null, udf.evaluate(null));
+    }
+
+    @Test
+    public void testEmpty() {
+        Assert.assertEquals("", udf.evaluate(""));
+    }
+
+    @Test
+    public void testUnchanged() {
+        Assert.assertEquals("christmas", udf.evaluate("christmas"));
+    }
+
+    @Test
+    public void testCompound() {
+        Assert.assertEquals("mother-in-law", udf.evaluate("mothers-in-law"));
+    }
+
+    @Test
+    public void testTailSingleQuote() {
+        Assert.assertEquals("dog's", udf.evaluate("dogs'"));
+    }
+
+    @Test
+    public void testIrregular() {
+        Assert.assertEquals("child", udf.evaluate("children"));
+    }
+
+    @Test
+    public void testRule() {
+        Assert.assertEquals("apple", udf.evaluate("apples"));
+        Assert.assertEquals("bus", udf.evaluate("buses"));
+        Assert.assertEquals("candy", udf.evaluate("candies"));
+    }
+
+}

--- a/docs/gitbook/misc/generic_funcs.md
+++ b/docs/gitbook/misc/generic_funcs.md
@@ -184,6 +184,14 @@ The compression level must be in range [-1,9]
 
 - `is_stopword(string word)` - Returns whether English stopword or not
 
+- `singularize(string word)` - Returns singular form of a given English word
+
+    ```sql
+    select singularize(lower("Apples"));
+
+    > "apple"
+    ```
+
 - `tokenize(string englishText [, boolean toLowerCase])` - Returns words in array<string>
 
 - `tokenize_ja(String line [, const string mode = "normal", const list<string> stopWords, const list<string> stopTags])` - returns tokenized strings in array<string>. Refer [this article](../misc/tokenizer.html) for detail.

--- a/resources/ddl/define-all-as-permanent.hive
+++ b/resources/ddl/define-all-as-permanent.hive
@@ -528,6 +528,9 @@ CREATE FUNCTION tokenize as 'hivemall.tools.text.TokenizeUDF' USING JAR '${hivem
 DROP FUNCTION IF EXISTS is_stopword;
 CREATE FUNCTION is_stopword as 'hivemall.tools.text.StopwordUDF' USING JAR '${hivemall_jar}';
 
+DROP FUNCTION IF EXISTS singularize;
+CREATE FUNCTION singularize as 'hivemall.tools.text.SingularizeUDF' USING JAR '${hivemall_jar}';
+
 DROP FUNCTION IF EXISTS split_words;
 CREATE FUNCTION split_words as 'hivemall.tools.text.SplitWordsUDF' USING JAR '${hivemall_jar}';
 

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -520,6 +520,9 @@ create temporary function tokenize as 'hivemall.tools.text.TokenizeUDF';
 drop temporary function if exists is_stopword;
 create temporary function is_stopword as 'hivemall.tools.text.StopwordUDF';
 
+drop temporary function if exists singularize;
+create temporary function singularize as 'hivemall.tools.text.SingularizeUDF';
+
 drop temporary function if exists split_words;
 create temporary function split_words as 'hivemall.tools.text.SplitWordsUDF';
 

--- a/resources/ddl/define-all.spark
+++ b/resources/ddl/define-all.spark
@@ -504,6 +504,9 @@ sqlContext.sql("CREATE TEMPORARY FUNCTION tokenize AS 'hivemall.tools.text.Token
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS is_stopword")
 sqlContext.sql("CREATE TEMPORARY FUNCTION is_stopword AS 'hivemall.tools.text.StopwordUDF'")
 
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS singularize")
+sqlContext.sql("CREATE TEMPORARY FUNCTION singularize AS 'hivemall.tools.text.SingularizeUDF'")
+
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS split_words")
 sqlContext.sql("CREATE TEMPORARY FUNCTION split_words AS 'hivemall.tools.text.SplitWordsUDF'")
 

--- a/resources/ddl/define-udfs.td.hql
+++ b/resources/ddl/define-udfs.td.hql
@@ -174,6 +174,7 @@ create temporary function dimsum_mapper as 'hivemall.knn.similarity.DIMSUMMapper
 create temporary function train_classifier as 'hivemall.classifier.GeneralClassifierUDTF';
 create temporary function train_regressor as 'hivemall.regression.GeneralRegressorUDTF';
 create temporary function tree_export as 'hivemall.smile.tools.TreeExportUDF';
+create temporary function singularize as 'hivemall.tools.text.SingularizeUDF';
 
 -- NLP features
 create temporary function tokenize_ja as 'hivemall.nlp.tokenizer.KuromojiUDF';


### PR DESCRIPTION
## What changes were proposed in this pull request?

Implement `singularize(string word)` to obtain singular form of `word`.

The implementation referred the following third-party code:

- https://github.com/sundrio/sundrio/blob/95c2b11f7b842bdaa04f61e8e338aea60fb38f70/codegen/src/main/java/io/sundr/codegen/functions/Singularize.java
- https://github.com/clips/pattern/blob/3eef00481a4555331cf9a099308910d977f6fc22/pattern/text/en/inflect.py#L445-L623

## What type of PR is it?

Feature

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-142

## How was this patch tested?

unit test & manual test on EMR

## How to use this feature?

as documented

## Checklist

- [x] Did you apply source code formatter, i.e., `mvn formatter:format`, for your commit?
