### PR TITLE
[HIVEMALL-136][SPARK] Support train_classifier and train_regressor for Spark 

### DIFF
--- a/spark/spark-2.1/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
+++ b/spark/spark-2.1/src/main/scala/org/apache/spark/sql/hive/HivemallOps.scala
@@ -64,6 +64,21 @@ final class HivemallOps(df: DataFrame) extends Logging {
   private[this] lazy val _strategy = new UserProvidedPlanner(_sparkSession.sqlContext.conf)
 
   /**
+   * @see [[hivemall.regression.GeneralRegressorUDTF]]
+   * @group regression
+   */
+  @scala.annotation.varargs
+  def train_regressor(exprs: Column*): DataFrame = withTypedPlan {
+    planHiveGenericUDTF(
+      df,
+      "hivemall.regression.GeneralRegressorUDTF",
+      "train_regressor",
+      toHivemallFeatures(exprs),
+      Seq("feature", "weight")
+    )
+  }
+
+  /**
    * @see [[hivemall.regression.AdaDeltaUDTF]]
    * @group regression
    */
@@ -225,6 +240,21 @@ final class HivemallOps(df: DataFrame) extends Logging {
       "train_randomforest_regr",
       setMixServs(toHivemallFeatures(exprs)),
       Seq("model_id", "model_type", "pred_model", "var_importance", "oob_errors", "oob_tests")
+    )
+  }
+
+  /**
+   * @see [[hivemall.classifier.GeneralClassifierUDTF]]
+   * @group classifier
+   */
+  @scala.annotation.varargs
+  def train_classifier(exprs: Column*): DataFrame = withTypedPlan {
+    planHiveGenericUDTF(
+      df,
+      "hivemall.classifier.GeneralClassifierUDTF",
+      "train_classifier",
+      toHivemallFeatures(exprs),
+      Seq("feature", "weight")
     )
   }
 

--- a/spark/spark-2.1/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
+++ b/spark/spark-2.1/src/test/scala/org/apache/spark/sql/hive/HivemallOpsSuite.scala
@@ -566,6 +566,7 @@ final class HivemallOpsWithFeatureSuite extends HivemallFeatureQueryTest {
   test("invoke regression functions") {
     import hiveContext.implicits._
     Seq(
+      "train_regressor",
       "train_adadelta",
       "train_adagrad",
       "train_arow_regr",
@@ -585,6 +586,7 @@ final class HivemallOpsWithFeatureSuite extends HivemallFeatureQueryTest {
   test("invoke classifier functions") {
     import hiveContext.implicits._
     Seq(
+      "train_classifier",
       "train_perceptron",
       "train_pa",
       "train_pa1",
@@ -729,6 +731,7 @@ final class HivemallOpsWithFeatureSuite extends HivemallFeatureQueryTest {
 
   ignore("check regression precision") {
     Seq(
+      "train_regressor",
       "train_adadelta",
       "train_adagrad",
       "train_arow_regr",
@@ -746,6 +749,7 @@ final class HivemallOpsWithFeatureSuite extends HivemallFeatureQueryTest {
 
   ignore("check classifier precision") {
     Seq(
+      "train_classifier",
       "train_perceptron",
       "train_pa",
       "train_pa1",


### PR DESCRIPTION
## What changes were proposed in this pull request?
This pr added functions `train_classifier` and `train_regressor` in `HivemallOps`.

## What type of PR is it?
Improvement

## What is the Jira issue?
https://issues.apache.org/jira/browse/HIVEMALL-136

## How was this patch tested?
Added tests in `HivemallOpsWithFeatureSuite`.