### PR TITLE
[HIVEMALL-164] Fixed pom for appending proper NOTICE/LICENSE/DISCLAIMER to jars

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -238,7 +238,21 @@
 										<Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
 									</manifestEntries>
 								</transformer>
+								<!--
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+									<addHeader>false</addHeader>
+								</transformer>
+								-->
 							</transformers>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/LICENSE.txt</exclude>
+										<exclude>META-INF/NOTICE.txt</exclude>
+									</excludes>
+								</filter>
+							</filters>
 						</configuration>
 					</execution>
 				</executions>

--- a/mixserv/pom.xml
+++ b/mixserv/pom.xml
@@ -178,6 +178,13 @@
 								this issue as described in the URL below http://stackoverflow.com/questions/8817257/minimize-an-uber-jar-correctly-using-shade-plugin -->
 							<filters>
 								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/LICENSE.txt</exclude>
+										<exclude>META-INF/NOTICE.txt</exclude>
+									</excludes>
+								</filter>
+								<filter>
 									<artifact>commons-logging:commons-logging</artifact>
 									<includes>
 										<include>**</include>

--- a/nlp/pom.xml
+++ b/nlp/pom.xml
@@ -184,6 +184,12 @@
 							</artifactSet>
 							<filters>
 								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/LICENSE.txt</exclude>
+									</excludes>
+								</filter>
+								<filter>
 									<artifact>org.apache.lucene:lucene-analyzers-kuromoji</artifact>
 									<includes>
 										<include>**</include>
@@ -216,6 +222,9 @@
 										<Implementation-Version>${project.version}</Implementation-Version>
 										<Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
 									</manifestEntries>
+								</transformer>
+								<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+									<addHeader>false</addHeader>
 								</transformer>
 							</transformers>
 						</configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -522,6 +522,40 @@
 						</execution>
 					</executions>
 				</plugin>
+				<!-- Copy LICENSE/NOTICE/DISCLAIMER to jar -->
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-remote-resources-plugin</artifactId>
+					<configuration>
+						<skip>true</skip>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-resources-plugin</artifactId>
+					<executions>
+						<execution>
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${project.basedir}/target/classes/META-INF</outputDirectory>
+							<resources>
+								<resource>
+								<directory>${main.basedir}/</directory>
+								<includes>
+									<include>LICENSE</include>
+									<include>NOTICE</include>
+									<include>DISCLAIMER</include>
+								</includes>
+								</resource>
+							</resources>
+						</configuration>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 
@@ -690,25 +724,6 @@
 				<configuration>
 					<tagNameFormat>v@{project.version}</tagNameFormat>
 				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-remote-resources-plugin</artifactId>
-				<executions>
-					<execution>
-						<goals>
-							<goal>process</goal>
-						</goals>
-						<configuration>
-							<resourceBundles>
-								<!-- Will generate META-INF/DEPENDENCIES META-INF/LICENSE META-INF/NOTICE -->
-								<resourceBundle>org.apache.apache.resources:apache-jar-resource-bundle:1.5-SNAPSHOT</resourceBundle>
-								<!-- Will generate META-INF/DISCLAIMER  -->
-								<resourceBundle>org.apache.apache.resources:apache-incubator-disclaimer-resource-bundle:1.2-SNAPSHOT</resourceBundle>
-							</resourceBundles>
-						</configuration>
-					</execution>
-				</executions>
 			</plugin>
 		</plugins>
 	</build>

--- a/xgboost/pom.xml
+++ b/xgboost/pom.xml
@@ -168,6 +168,14 @@
 									<include>ml.dmlc:xgboost4j</include>
 								</includes>
 							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>tracker.py</exclude>
+									</excludes>
+								</filter>
+							</filters>
 						</configuration>
 					</execution>
 					<!-- hivemall-xgboost_xx-xx-with-dependencies.jar including minimum dependencies -->
@@ -194,6 +202,15 @@
 									<include>com.esotericsoftware.kryo:kryo</include>
 								</includes>
 							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>*.jar</exclude>
+										<exclude>tracker.py</exclude>
+									</excludes>
+								</filter>
+							</filters>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed pom for appending proper NOTICE/LICENSE/DISCLAIMER to jars. `maven-remote-resources-plugin` used in parent Apache pom does not work well.

This PR closes #128

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-164

## How was this patch tested?

manual tests

## How to use this feature?

`./bin/build.sh`