### PR TITLE
[HIVEMALL-191] Add Kryo serialization test to existing workaround code

### DIFF
--- a/core/src/main/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTF.java
+++ b/core/src/main/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTF.java
@@ -19,6 +19,7 @@
 package hivemall.ftvec.trans;
 
 import hivemall.utils.hadoop.HiveUtils;
+import hivemall.utils.hadoop.WritableUtils;
 import hivemall.utils.lang.Identifier;
 
 import java.util.ArrayList;
@@ -29,7 +30,6 @@ import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
-import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
@@ -46,7 +46,6 @@ public final class QuantifiedFeaturesUDTF extends GenericUDTF {
     private BooleanObjectInspector boolOI;
     private PrimitiveObjectInspector[] doubleOIs;
     private Identifier<String>[] identifiers;
-    private DoubleWritable[] columnValues;
 
     @SuppressWarnings("unchecked")
     @Override
@@ -60,11 +59,9 @@ public final class QuantifiedFeaturesUDTF extends GenericUDTF {
 
         int outputSize = size - 1;
         this.doubleOIs = new PrimitiveObjectInspector[outputSize];
-        this.columnValues = new DoubleWritable[outputSize];
         this.identifiers = new Identifier[outputSize];
 
         for (int i = 0; i < outputSize; i++) {
-            columnValues[i] = new DoubleWritable(Double.NaN);
             ObjectInspector argOI = argOIs[i + 1];
             if (HiveUtils.isNumberOI(argOI)) {
                 doubleOIs[i] = HiveUtils.asDoubleCompatibleOI(argOI);
@@ -86,24 +83,24 @@ public final class QuantifiedFeaturesUDTF extends GenericUDTF {
         boolean outputRow = boolOI.get(args[0]);
         if (outputRow) {
             int outputSize = args.length - 1;
-            final Object[] forwardObjs = new Object[outputSize];
+            double[] values = new double[outputSize];
             for (int i = 0; i < outputSize; i++) {
                 Object arg = args[i + 1];
                 Identifier<String> identifier = identifiers[i];
                 if (identifier == null) {
                     double v = PrimitiveObjectInspectorUtils.getDouble(arg, doubleOIs[i]);
-                    forwardObjs[i] = v;
+                    values[i] = v;
                 } else {
                     if (arg == null) {
                         throw new HiveException("Found Null in the input: " + Arrays.toString(args));
                     } else {
                         String k = arg.toString();
                         int id = identifier.valueOf(k);
-                        forwardObjs[i] = id;
+                        values[i] = id;
                     }
                 }
             }
-            forward(forwardObjs);
+            forward(new Object[] {WritableUtils.toWritableList(values)});
         } else {// load only
             for (int i = 0, outputSize = args.length - 1; i < outputSize; i++) {
                 Identifier<String> identifier = identifiers[i];
@@ -123,7 +120,6 @@ public final class QuantifiedFeaturesUDTF extends GenericUDTF {
         this.boolOI = null;
         this.doubleOIs = null;
         this.identifiers = null;
-        this.columnValues = null;
     }
 
 }

--- a/core/src/test/java/hivemall/TestUtils.java
+++ b/core/src/test/java/hivemall/TestUtils.java
@@ -19,15 +19,85 @@
 package hivemall;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 import javax.annotation.Nonnull;
 
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.Collector;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hive.com.esotericsoftware.kryo.Kryo;
 import org.apache.hive.com.esotericsoftware.kryo.io.Input;
 import org.apache.hive.com.esotericsoftware.kryo.io.Output;
 
 public final class TestUtils {
+
+    public static <T extends GenericUDF> void testGenericUDFSerialization(@Nonnull Class<T> clazz,
+            @Nonnull ObjectInspector[] ois, @Nonnull Object[] row) throws HiveException,
+            IOException {
+        final T udf;
+        try {
+            udf = clazz.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new HiveException(e);
+        }
+
+        udf.initialize(ois);
+
+        // serialization after initialization
+        byte[] serialized = serializeObjectByKryo(udf);
+        deserializeObjectByKryo(serialized, clazz);
+
+        int size = row.length;
+        GenericUDF.DeferredObject[] rowDeferred = new GenericUDF.DeferredObject[size];
+        for (int i = 0; i < size; i++) {
+            rowDeferred[i] = new GenericUDF.DeferredJavaObject(row[i]);
+        }
+
+        udf.evaluate(rowDeferred);
+
+        // serialization after evaluating row
+        serialized = serializeObjectByKryo(udf);
+        TestUtils.deserializeObjectByKryo(serialized, clazz);
+
+        udf.close();
+    }
+
+    public static <T extends GenericUDTF> void testGenericUDTFSerialization(
+            @Nonnull Class<T> clazz, @Nonnull ObjectInspector[] ois, @Nonnull Object[][] rows)
+            throws HiveException {
+        final T udtf;
+        try {
+            udtf = clazz.newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            throw new HiveException(e);
+        }
+
+        udtf.initialize(ois);
+
+        // serialization after initialization
+        byte[] serialized = serializeObjectByKryo(udtf);
+        deserializeObjectByKryo(serialized, clazz);
+
+        udtf.setCollector(new Collector() {
+            public void collect(Object input) throws HiveException {
+                // noop
+            }
+        });
+
+        for (Object[] row : rows) {
+            udtf.process(row);
+        }
+
+        // serialization after processing row
+        serialized = serializeObjectByKryo(udtf);
+        TestUtils.deserializeObjectByKryo(serialized, clazz);
+
+        udtf.close();
+    }
 
     @Nonnull
     public static byte[] serializeObjectByKryo(@Nonnull Object obj) {

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -21,6 +21,8 @@ package hivemall.classifier;
 import static hivemall.utils.hadoop.HiveUtils.lazyInteger;
 import static hivemall.utils.hadoop.HiveUtils.lazyLong;
 import static hivemall.utils.hadoop.HiveUtils.lazyString;
+
+import hivemall.TestUtils;
 import hivemall.utils.math.MathUtils;
 
 import java.io.BufferedReader;
@@ -366,6 +368,16 @@ public class GeneralClassifierUDTFTest {
         float accuracy = numCorrect / (float) numTests;
         println("Accuracy: " + accuracy);
         Assert.assertTrue(accuracy > 0.8f);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            GeneralClassifierUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector}, new Object[][] {{
+                    Arrays.asList("1:-2", "2:-1"), 0}});
     }
 
     private static void println(String msg) {

--- a/core/src/test/java/hivemall/classifier/KernelExpansionPassiveAggressiveUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/KernelExpansionPassiveAggressiveUDTFTest.java
@@ -18,6 +18,7 @@
  */
 package hivemall.classifier;
 
+import hivemall.TestUtils;
 import hivemall.model.FeatureValue;
 import hivemall.utils.math.MathUtils;
 
@@ -27,6 +28,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.text.ParseException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.StringTokenizer;
 import java.util.zip.GZIPInputStream;
 
@@ -144,6 +146,16 @@ public class KernelExpansionPassiveAggressiveUDTFTest {
 
         float accuracy = numCorrect / (float) numTests;
         Assert.assertTrue(accuracy > 0.82f);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            KernelExpansionPassiveAggressiveUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector}, new Object[][] {{
+                    Arrays.asList("1:-2", "2:-1"), 0}});
     }
 
     @Nonnull

--- a/core/src/test/java/hivemall/classifier/PassiveAggressiveUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/PassiveAggressiveUDTFTest.java
@@ -19,9 +19,12 @@
 package hivemall.classifier;
 
 import static org.junit.Assert.assertEquals;
+
+import hivemall.TestUtils;
 import hivemall.model.PredictionResult;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
@@ -219,6 +222,26 @@ public class PassiveAggressiveUDTFTest {
         PredictionResult margin2 = new PredictionResult(0.5f).squaredNorm(0.01f);
         float expectedLearningRate2 = 0.5660377f;
         assertEquals(expectedLearningRate2, udtf.eta(loss, margin2), 1e-5f);
+    }
+
+    @Test
+    public void testPA1Serialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            PassiveAggressiveUDTF.PA1.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector}, new Object[][] {{
+                    Arrays.asList("1:-2", "2:-1"), 0}});
+    }
+
+    @Test
+    public void testPA2Serialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            PassiveAggressiveUDTF.PA2.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector}, new Object[][] {{
+                    Arrays.asList("1:-2", "2:-1"), 0}});
     }
 
 }

--- a/core/src/test/java/hivemall/classifier/PerceptronUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/PerceptronUDTFTest.java
@@ -19,9 +19,12 @@
 package hivemall.classifier;
 
 import static org.junit.Assert.assertEquals;
+
+import hivemall.TestUtils;
 import hivemall.model.FeatureValue;
 
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -29,6 +32,8 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 public class PerceptronUDTFTest {
 
@@ -117,5 +122,15 @@ public class PerceptronUDTFTest {
         assertEquals(1.f, udtf.model.get(word1.getFeature()).get(), 1e-5f);
         assertEquals(-1.f, udtf.model.get(word3.getFeature()).get(), 1e-5f);
         assertEquals(0.f, udtf.model.get(word4.getFeature()).get(), 1e-5f);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            PerceptronUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector}, new Object[][] {{
+                    Arrays.asList("1:-2", "2:-1"), 0}});
     }
 }

--- a/core/src/test/java/hivemall/fm/FactorizationMachineUDTFTest.java
+++ b/core/src/test/java/hivemall/fm/FactorizationMachineUDTFTest.java
@@ -23,12 +23,14 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.zip.GZIPInputStream;
 
 import javax.annotation.Nonnull;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -100,6 +102,19 @@ public class FactorizationMachineUDTFTest {
         udtf.initialize(argOIs);
         udtf.initModel(udtf._params);
         Assert.assertTrue(udtf._params.l2norm);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            FactorizationMachineUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        "-factors 5 -min 1 -max 5 -iters 1 -init_v gaussian -eta0 0.01 -seed 31")},
+            new Object[][] {{Arrays.asList("1:-2", "2:-1"), 1.0}});
     }
 
     @Nonnull

--- a/core/src/test/java/hivemall/fm/FieldAwareFactorizationMachineUDTFTest.java
+++ b/core/src/test/java/hivemall/fm/FieldAwareFactorizationMachineUDTFTest.java
@@ -18,6 +18,7 @@
  */
 package hivemall.fm;
 
+import hivemall.TestUtils;
 import hivemall.utils.lang.NumberUtils;
 
 import java.io.BufferedReader;
@@ -26,6 +27,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
@@ -210,6 +212,19 @@ public class FieldAwareFactorizationMachineUDTFTest {
         }
         println("model size=" + udtf._model.getSize());
         Assert.assertTrue("Last loss was greater than expected: " + loss, loss < lossThreshold);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            FieldAwareFactorizationMachineUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        "-opt sgd -classification -factors 10 -w0 -seed 43")}, new Object[][] {{
+                    Arrays.asList("0:1:-2", "1:2:-1"), 1.0}});
     }
 
     @Nonnull

--- a/core/src/test/java/hivemall/ftvec/FeatureUDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/FeatureUDFTest.java
@@ -18,7 +18,9 @@
  */
 package hivemall.ftvec;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
@@ -28,6 +30,8 @@ import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.io.IOException;
 
 public class FeatureUDFTest {
     FeatureUDF udf = null;
@@ -225,4 +229,13 @@ public class FeatureUDFTest {
         Assert.assertNull(ret);
 
     }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(FeatureUDF.class, new ObjectInspector[] {
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector}, new Object[] {"f1",
+                2.5d});
+    }
+
 }

--- a/core/src/test/java/hivemall/ftvec/hashing/FeatureHashingUDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/hashing/FeatureHashingUDFTest.java
@@ -18,10 +18,19 @@
  */
 package hivemall.ftvec.hashing;
 
+import hivemall.TestUtils;
 import hivemall.utils.hashing.MurmurHash3;
 
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 public class FeatureHashingUDFTest {
 
@@ -39,6 +48,17 @@ public class FeatureHashingUDFTest {
         actual = FeatureHashingUDF.featureHashing(expected, MurmurHash3.DEFAULT_NUM_FEATURES);
         Assert.assertEquals(
             FeatureHashingUDF.mhash("0", MurmurHash3.DEFAULT_NUM_FEATURES) + ":1.1", actual);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            FeatureHashingUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-features 1")},
+            new Object[] {Arrays.asList("aaa#xxx", "bbb:10")});
     }
 
 }

--- a/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
+++ b/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
@@ -45,10 +45,6 @@ public class QuantifiedFeaturesUDTFTest {
                 PrimitiveObjectInspectorFactory.javaStringObjectInspector,
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector});
 
-        // serialization after initialization
-        byte[] serialized = TestUtils.serializeObjectByKryo(udtf);
-        TestUtils.deserializeObjectByKryo(serialized, QuantifiedFeaturesUDTF.class);
-
         final List<Object[]> rows = new ArrayList<>();
         udtf.setCollector(new Collector() {
             public void collect(Object input) throws HiveException {
@@ -58,10 +54,6 @@ public class QuantifiedFeaturesUDTFTest {
 
         udtf.process(new Object[] {WritableUtils.val(true), "aaa", 1.0});
         udtf.process(new Object[] {WritableUtils.val(true), "bbb", 2.0});
-
-        // serialization after processing rows
-        serialized = TestUtils.serializeObjectByKryo(udtf);
-        TestUtils.deserializeObjectByKryo(serialized, QuantifiedFeaturesUDTF.class);
 
         udtf.close();
 
@@ -74,5 +66,17 @@ public class QuantifiedFeaturesUDTFTest {
         features = (List<DoubleWritable>) rows.get(1)[0];
         Assert.assertTrue(features.get(0).get() == 1.d);
         Assert.assertTrue(features.get(1).get() == 2.d);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            QuantifiedFeaturesUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaBooleanObjectInspector, true),
+                    PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector}, new Object[][] {{
+                    WritableUtils.val(true), "aaa", 1.0}});
     }
 }

--- a/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
+++ b/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
@@ -22,11 +22,9 @@ public class QuantifiedFeaturesUDTFTest {
 
         udtf.initialize(new ObjectInspector[] {
                 ObjectInspectorUtils.getConstantObjectInspector(
-                        PrimitiveObjectInspectorFactory.javaBooleanObjectInspector,
-                        true),
+                    PrimitiveObjectInspectorFactory.javaBooleanObjectInspector, true),
                 PrimitiveObjectInspectorFactory.javaStringObjectInspector,
-                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
-        });
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector});
 
         final List<Object[]> featuresList = new ArrayList<>();
         udtf.setCollector(new Collector() {

--- a/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
+++ b/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
@@ -45,10 +45,16 @@ public class QuantifiedFeaturesUDTFTest {
                 PrimitiveObjectInspectorFactory.javaStringObjectInspector,
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector});
 
-        final List<Object[]> rows = new ArrayList<>();
+        final List<List<Double>> quantifiedInputs = new ArrayList<>();
         udtf.setCollector(new Collector() {
             public void collect(Object input) throws HiveException {
-                rows.add((Object[]) input);
+                Object[] row = (Object[]) input;
+                List<DoubleWritable> column = (List<DoubleWritable>) row[0];
+                List<Double> quantifiedInput = new ArrayList<>();
+                for (DoubleWritable elem : column) {
+                    quantifiedInput.add(elem.get());
+                }
+                quantifiedInputs.add(quantifiedInput);
             }
         });
 
@@ -57,15 +63,15 @@ public class QuantifiedFeaturesUDTFTest {
 
         udtf.close();
 
-        Assert.assertEquals(2, rows.size());
+        Assert.assertEquals(2, quantifiedInputs.size());
 
-        List<DoubleWritable> features = (List<DoubleWritable>) rows.get(0)[0];
-        Assert.assertTrue(features.get(0).get() == 0.d);
-        Assert.assertTrue(features.get(1).get() == 1.d);
+        List<Double> quantifiedInput = quantifiedInputs.get(0);
+        Assert.assertTrue(quantifiedInput.get(0) == 0.d);
+        Assert.assertTrue(quantifiedInput.get(1) == 1.d);
 
-        features = (List<DoubleWritable>) rows.get(1)[0];
-        Assert.assertTrue(features.get(0).get() == 1.d);
-        Assert.assertTrue(features.get(1).get() == 2.d);
+        quantifiedInput = quantifiedInputs.get(1);
+        Assert.assertTrue(quantifiedInput.get(0) == 1.d);
+        Assert.assertTrue(quantifiedInput.get(1) == 2.d);
     }
 
     @Test

--- a/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
+++ b/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.ftvec.trans;
 
 import hivemall.TestUtils;

--- a/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
+++ b/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
@@ -1,0 +1,57 @@
+package hivemall.ftvec.trans;
+
+import hivemall.TestUtils;
+import hivemall.utils.hadoop.WritableUtils;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+
+import org.apache.hadoop.hive.ql.udf.generic.Collector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class QuantifiedFeaturesUDTFTest {
+
+    @Test
+    public void testSerialization() throws HiveException {
+        final QuantifiedFeaturesUDTF udtf = new QuantifiedFeaturesUDTF();
+
+        udtf.initialize(new ObjectInspector[] {
+                ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaBooleanObjectInspector,
+                        true),
+                PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector
+        });
+
+        final List<Object[]> featuresList = new ArrayList<>();
+        udtf.setCollector(new Collector() {
+            public void collect(Object input) throws HiveException {
+                featuresList.add((Object[]) input);
+            }
+        });
+
+        udtf.process(new Object[] {WritableUtils.val(true), "aaa", 1.0});
+        udtf.process(new Object[] {WritableUtils.val(true), "bbb", 2.0});
+
+        // test Kryo serialization
+        byte[] serialized = TestUtils.serializeObjectByKryo(udtf);
+        TestUtils.deserializeObjectByKryo(serialized, QuantifiedFeaturesUDTF.class);
+
+        udtf.close();
+
+        Assert.assertEquals(2, featuresList.size());
+
+        Object[] features = featuresList.get(0);
+        Assert.assertEquals(0, ((Integer) features[0]).intValue());
+        Assert.assertEquals(1, ((Double) features[1]).intValue());
+
+        features = featuresList.get(1);
+        Assert.assertEquals(1, ((Integer) features[0]).intValue());
+        Assert.assertEquals(2, ((Double) features[1]).intValue());
+    }
+}

--- a/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
+++ b/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
@@ -45,6 +45,10 @@ public class QuantifiedFeaturesUDTFTest {
                 PrimitiveObjectInspectorFactory.javaStringObjectInspector,
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector});
 
+        // serialization after initialization
+        byte[] serialized = TestUtils.serializeObjectByKryo(udtf);
+        TestUtils.deserializeObjectByKryo(serialized, QuantifiedFeaturesUDTF.class);
+
         final List<Object[]> rows = new ArrayList<>();
         udtf.setCollector(new Collector() {
             public void collect(Object input) throws HiveException {
@@ -55,8 +59,8 @@ public class QuantifiedFeaturesUDTFTest {
         udtf.process(new Object[] {WritableUtils.val(true), "aaa", 1.0});
         udtf.process(new Object[] {WritableUtils.val(true), "bbb", 2.0});
 
-        // test Kryo serialization
-        byte[] serialized = TestUtils.serializeObjectByKryo(udtf);
+        // serialization after processing rows
+        serialized = TestUtils.serializeObjectByKryo(udtf);
         TestUtils.deserializeObjectByKryo(serialized, QuantifiedFeaturesUDTF.class);
 
         udtf.close();

--- a/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
+++ b/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
@@ -23,6 +23,7 @@ import hivemall.utils.hadoop.WritableUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 
 import org.apache.hadoop.hive.ql.udf.generic.Collector;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
@@ -44,10 +45,10 @@ public class QuantifiedFeaturesUDTFTest {
                 PrimitiveObjectInspectorFactory.javaStringObjectInspector,
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector});
 
-        final List<Object[]> featuresList = new ArrayList<>();
+        final List<Object[]> rows = new ArrayList<>();
         udtf.setCollector(new Collector() {
             public void collect(Object input) throws HiveException {
-                featuresList.add((Object[]) input);
+                rows.add((Object[]) input);
             }
         });
 
@@ -60,14 +61,14 @@ public class QuantifiedFeaturesUDTFTest {
 
         udtf.close();
 
-        Assert.assertEquals(2, featuresList.size());
+        Assert.assertEquals(2, rows.size());
 
-        Object[] features = featuresList.get(0);
-        Assert.assertEquals(0, ((Integer) features[0]).intValue());
-        Assert.assertEquals(1, ((Double) features[1]).intValue());
+        List<DoubleWritable> features = (List<DoubleWritable>) rows.get(0)[0];
+        Assert.assertTrue(features.get(0).get() == 0.d);
+        Assert.assertTrue(features.get(1).get() == 1.d);
 
-        features = featuresList.get(1);
-        Assert.assertEquals(1, ((Integer) features[0]).intValue());
-        Assert.assertEquals(2, ((Double) features[1]).intValue());
+        features = (List<DoubleWritable>) rows.get(1)[0];
+        Assert.assertTrue(features.get(0).get() == 1.d);
+        Assert.assertTrue(features.get(1).get() == 2.d);
     }
 }

--- a/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
+++ b/core/src/test/java/hivemall/ftvec/trans/QuantifiedFeaturesUDTFTest.java
@@ -36,7 +36,7 @@ import java.util.List;
 public class QuantifiedFeaturesUDTFTest {
 
     @Test
-    public void testSerialization() throws HiveException {
+    public void test() throws HiveException {
         final QuantifiedFeaturesUDTF udtf = new QuantifiedFeaturesUDTF();
 
         udtf.initialize(new ObjectInspector[] {

--- a/core/src/test/java/hivemall/ftvec/trans/TestBinarizeLabelUDTF.java
+++ b/core/src/test/java/hivemall/ftvec/trans/TestBinarizeLabelUDTF.java
@@ -24,6 +24,8 @@ import static org.mockito.Mockito.times;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.verifyPrivate;
+
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.util.Arrays;
@@ -103,5 +105,18 @@ public class TestBinarizeLabelUDTF {
         udtf.process(arguments);
 
         verifyPrivate(udtf, times(0)).invoke("forward", any(Object[].class));
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        final List<String> featureNames = Arrays.asList("positive", "negative", "features");
+        TestUtils.testGenericUDTFSerialization(
+            BinarizeLabelUDTF.class,
+            new ObjectInspector[] {
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    ObjectInspectorFactory.getStandardConstantListObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector, featureNames)},
+            new Object[][] {{new Integer(0), new Integer(0), WritableUtils.val("a:1", "b:2")}});
     }
 }

--- a/core/src/test/java/hivemall/ftvec/trans/VectorizeFeaturesUDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/trans/VectorizeFeaturesUDFTest.java
@@ -18,6 +18,7 @@
  */
 package hivemall.ftvec.trans;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.io.IOException;
@@ -88,7 +89,7 @@ public class VectorizeFeaturesUDFTest {
         arguments[2] = new DeferredJavaObject("1.1");
 
         List<Text> actuals = udf.evaluate(arguments);
-        //System.out.println(actuals);        
+        //System.out.println(actuals);
         List<Text> expected = WritableUtils.val("a:0.1", "b:1.1");
         Assert.assertEquals(expected, actuals);
 
@@ -111,7 +112,7 @@ public class VectorizeFeaturesUDFTest {
         arguments[2] = new DeferredJavaObject("0");
 
         List<Text> actuals = udf.evaluate(arguments);
-        //System.out.println(actuals);        
+        //System.out.println(actuals);
         List<Text> expected = WritableUtils.val(new String[] {"a:0.1"});
         Assert.assertEquals(expected, actuals);
 
@@ -134,7 +135,7 @@ public class VectorizeFeaturesUDFTest {
         arguments[2] = new DeferredJavaObject(new Boolean(false));
 
         List<Text> actuals = udf.evaluate(arguments);
-        //System.out.println(actuals);        
+        //System.out.println(actuals);
         List<Text> expected = WritableUtils.val(new String[] {"a:0.1"});
         Assert.assertEquals(expected, actuals);
 
@@ -163,19 +164,19 @@ public class VectorizeFeaturesUDFTest {
         arguments[2] = new DeferredJavaObject("dayofweek");
 
         List<Text> actuals = udf.evaluate(arguments);
-        //System.out.println(actuals);        
+        //System.out.println(actuals);
         List<Text> expected = WritableUtils.val("a:0.1", "b#dayofweek");
         Assert.assertEquals(expected, actuals);
 
         arguments[2] = new DeferredJavaObject("1.0");
         actuals = udf.evaluate(arguments);
-        //System.out.println(actuals);        
+        //System.out.println(actuals);
         expected = WritableUtils.val("a:0.1", "b:1.0");
         Assert.assertEquals(expected, actuals);
 
         arguments[2] = new DeferredJavaObject("1");
         actuals = udf.evaluate(arguments);
-        //System.out.println(actuals);        
+        //System.out.println(actuals);
         expected = WritableUtils.val("a:0.1", "b:1.0");
         Assert.assertEquals(expected, actuals);
 
@@ -186,6 +187,20 @@ public class VectorizeFeaturesUDFTest {
         Assert.assertEquals(expected, actuals);
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        final List<String> featureNames = Arrays.asList("q", "c");
+
+        TestUtils.testGenericUDFSerialization(
+            VectorizeFeaturesUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardConstantListObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector, featureNames),
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaStringObjectInspector}, new Object[] {
+                    featureNames, 0.1d, "dayofweek"});
     }
 
 }

--- a/core/src/test/java/hivemall/geospatial/HaversineDistanceUDFTest.java
+++ b/core/src/test/java/hivemall/geospatial/HaversineDistanceUDFTest.java
@@ -20,6 +20,7 @@ package hivemall.geospatial;
 
 import java.io.IOException;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
@@ -100,6 +101,25 @@ public class HaversineDistanceUDFTest {
         Assert.assertEquals(249.84d, result1.get(), 0.1d);
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        // Tokyo
+        double lat1 = 35.6833d, lon1 = 139.7667d;
+        // Osaka
+        double lat2 = 34.6603d, lon2 = 135.5232d;
+
+        TestUtils.testGenericUDFSerialization(
+            HaversineDistanceUDF.class,
+            new ObjectInspector[] {
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaBooleanObjectInspector, true)},
+            new Object[] {lat1, lon1, lat2, lon2, true});
     }
 
 }

--- a/core/src/test/java/hivemall/geospatial/Lat2TileYUDFTest.java
+++ b/core/src/test/java/hivemall/geospatial/Lat2TileYUDFTest.java
@@ -20,6 +20,7 @@ package hivemall.geospatial;
 
 import java.io.IOException;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
@@ -43,6 +44,14 @@ public class Lat2TileYUDFTest {
         Assert.assertEquals(2792, result1.get());
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(Lat2TileYUDF.class, new ObjectInspector[] {
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector}, new Object[] {49.60055d,
+                13});
     }
 
 }

--- a/core/src/test/java/hivemall/geospatial/Lon2TileXUDFTest.java
+++ b/core/src/test/java/hivemall/geospatial/Lon2TileXUDFTest.java
@@ -20,6 +20,7 @@ package hivemall.geospatial;
 
 import java.io.IOException;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
@@ -43,6 +44,14 @@ public class Lon2TileXUDFTest {
         Assert.assertEquals(4346, result1.get());
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(Lon2TileXUDF.class, new ObjectInspector[] {
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector}, new Object[] {11.01296d,
+                13});
     }
 
 }

--- a/core/src/test/java/hivemall/geospatial/TileX2LonUDFTest.java
+++ b/core/src/test/java/hivemall/geospatial/TileX2LonUDFTest.java
@@ -20,6 +20,7 @@ package hivemall.geospatial;
 
 import java.io.IOException;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
@@ -43,6 +44,13 @@ public class TileX2LonUDFTest {
         Assert.assertEquals(-23.95019531d, result.get(), 0.001);
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(TileX2LonUDF.class, new ObjectInspector[] {
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector}, new Object[] {3551, 13});
     }
 
 }

--- a/core/src/test/java/hivemall/geospatial/TileY2LatUDFTest.java
+++ b/core/src/test/java/hivemall/geospatial/TileY2LatUDFTest.java
@@ -20,6 +20,7 @@ package hivemall.geospatial;
 
 import java.io.IOException;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredJavaObject;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
@@ -43,6 +44,13 @@ public class TileY2LatUDFTest {
         Assert.assertEquals(83.99996604d, result.get(), 0.001);
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(TileY2LatUDF.class, new ObjectInspector[] {
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector}, new Object[] {503, 14});
     }
 
 }

--- a/core/src/test/java/hivemall/knn/distance/EuclidDistanceUDFTest.java
+++ b/core/src/test/java/hivemall/knn/distance/EuclidDistanceUDFTest.java
@@ -18,9 +18,15 @@
  */
 package hivemall.knn.distance;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import hivemall.TestUtils;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -40,6 +46,16 @@ public class EuclidDistanceUDFTest {
         List<String> ftvec2 = Arrays.asList("1:2.0", "3:6.0");
         double d = EuclidDistanceUDF.euclidDistance(ftvec1, ftvec2);
         Assert.assertEquals(Math.sqrt(1.0 + 9.0 + 9.0), d, 0.f);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            EuclidDistanceUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector)},
+            new Object[] {Arrays.asList("1:1.0", "2:3.0", "3:3.0"), Arrays.asList("1:2.0", "3:6.0")});
     }
 
 }

--- a/core/src/test/java/hivemall/knn/similarity/CosineSimilarityUDFTest.java
+++ b/core/src/test/java/hivemall/knn/similarity/CosineSimilarityUDFTest.java
@@ -22,6 +22,11 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import hivemall.TestUtils;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -106,5 +111,15 @@ public class CosineSimilarityUDFTest {
         Assert.assertEquals(1.f,
             CosineSimilarityUDF.cosineSimilarity(Arrays.asList("1", "2"), Arrays.asList("1", "2")),
             0.0);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            CosineSimilarityUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector)},
+            new Object[] {Arrays.asList("1:1.0", "2:3.0", "3:3.0"), Arrays.asList("1:2.0", "3:6.0")});
     }
 }

--- a/core/src/test/java/hivemall/knn/similarity/DIMSUMMapperUDTFTest.java
+++ b/core/src/test/java/hivemall/knn/similarity/DIMSUMMapperUDTFTest.java
@@ -18,6 +18,7 @@
  */
 package hivemall.knn.similarity;
 
+import hivemall.TestUtils;
 import hivemall.mf.BPRMatrixFactorizationUDTFTest;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.lang.StringUtils;
@@ -355,6 +356,29 @@ public class DIMSUMMapperUDTFTest {
 
         Assert.assertTrue("Approximated one MUST reduce the number of operations",
             emitCounter.getValue() < numMaxEmits);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        final Integer[] itemIDs = new Integer[] {1, 2, 3};
+
+        final List<String> user = new ArrayList<String>();
+        convertRowToFeatures(0, user, itemIDs);
+
+        final Map<Integer, Double> norms = new HashMap<Integer, Double>();
+        computeColumnNorms(norms, itemIDs);
+
+        TestUtils.testGenericUDTFSerialization(
+            DIMSUMMapperUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    ObjectInspectorFactory.getStandardMapObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        "-threshold 0.999999 -disable_symmetric_output")}, new Object[][] {{user,
+                    norms}});
     }
 
     @Nonnull

--- a/core/src/test/java/hivemall/mf/BPRMatrixFactorizationUDTFTest.java
+++ b/core/src/test/java/hivemall/mf/BPRMatrixFactorizationUDTFTest.java
@@ -18,6 +18,7 @@
  */
 package hivemall.mf;
 
+import hivemall.TestUtils;
 import hivemall.utils.lang.StringUtils;
 
 import java.io.BufferedReader;
@@ -109,6 +110,19 @@ public class BPRMatrixFactorizationUDTFTest {
         bpr.close();
         int finishedIter = bpr.cvState.getCurrentIteration();
         Assert.assertTrue("finishedIter: " + finishedIter, finishedIter < iterations);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            BPRMatrixFactorizationUDTF.class,
+            new ObjectInspector[] {
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        "-factor 10 -iter 1")}, new Object[][] {{0, 0, 1}});
     }
 
     @Nonnull

--- a/core/src/test/java/hivemall/mf/MatrixFactorizationAdaGradUDTFTest.java
+++ b/core/src/test/java/hivemall/mf/MatrixFactorizationAdaGradUDTFTest.java
@@ -18,6 +18,7 @@
  */
 package hivemall.mf;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
@@ -78,6 +79,19 @@ public class MatrixFactorizationAdaGradUDTFTest {
             }
             println();
         }
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            MatrixFactorizationAdaGradUDTF.class,
+            new ObjectInspector[] {
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaFloatObjectInspector,
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-factor 10")},
+            new Object[][] {{0, 0, 5.f}});
     }
 
 }

--- a/core/src/test/java/hivemall/mf/MatrixFactorizationSGDUDTFTest.java
+++ b/core/src/test/java/hivemall/mf/MatrixFactorizationSGDUDTFTest.java
@@ -18,6 +18,7 @@
  */
 package hivemall.mf;
 
+import hivemall.TestUtils;
 import hivemall.mf.FactorizedModel.RankInitScheme;
 import hivemall.utils.lang.mutable.MutableInt;
 
@@ -342,5 +343,18 @@ public class MatrixFactorizationSGDUDTFTest {
         Assert.assertEquals(trainingExamples * iters, mf.count);
         Assert.assertEquals(5, numCollected.intValue());
         Assert.assertFalse(tmpFile.exists());
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            MatrixFactorizationSGDUDTF.class,
+            new ObjectInspector[] {
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaFloatObjectInspector,
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-factor 10")},
+            new Object[][] {{0, 0, 5.f}});
     }
 }

--- a/core/src/test/java/hivemall/recommend/SlimUDTFTest.java
+++ b/core/src/test/java/hivemall/recommend/SlimUDTFTest.java
@@ -21,6 +21,7 @@ package hivemall.recommend;
 import java.util.HashMap;
 import java.util.Map;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -94,6 +95,77 @@ public class SlimUDTFTest {
             }
         }
         slim.finalizeTraining();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        int numUser = 4;
+        int numItem = 5;
+
+        float[][] data = { {1.f, 4.f, 0.f, 0.f, 0.f}, {0.f, 3.f, 0.f, 1.f, 2.f},
+                {2.f, 2.f, 0.f, 0.f, 3.f}, {0.f, 1.f, 1.f, 0.f, 0.f}};
+
+        Object[][] rows = new Object[numItem * (numItem - 1)][5];
+        int ri = 0;
+
+        for (int i = 0; i < numItem; i++) {
+            Map<Integer, Float> Ri = new HashMap<>();
+            for (int u = 0; u < numUser; u++) {
+                if (data[u][i] != 0.) {
+                    Ri.put(u, data[u][i]);
+                }
+            }
+
+            // most similar data
+            Map<Integer, Map<Integer, Float>> knnRatesOfI = new HashMap<>();
+            for (int u = 0; u < numUser; u++) {
+                Map<Integer, Float> Ru = new HashMap<>();
+                for (int k = 0; k < numItem; k++) {
+                    if (k == i)
+                        continue;
+                    Ru.put(k, data[u][k]);
+                }
+                knnRatesOfI.put(u, Ru);
+            }
+
+            for (int j = 0; j < numItem; j++) {
+                if (i == j)
+                    continue;
+                Map<Integer, Float> Rj = new HashMap<>();
+                for (int u = 0; u < numUser; u++) {
+                    if (data[u][j] != 0.) {
+                        Rj.put(u, data[u][j]);
+                    }
+                }
+
+                rows[ri][0] = i;
+                rows[ri][1] = Ri;
+                rows[ri][2] = knnRatesOfI;
+                rows[ri][3] = j;
+                rows[ri][4] = Rj;
+                ri += 1;
+            }
+        }
+
+        TestUtils.testGenericUDTFSerialization(
+            SlimUDTF.class,
+            new ObjectInspector[] {
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    ObjectInspectorFactory.getStandardMapObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaFloatObjectInspector),
+                    ObjectInspectorFactory.getStandardMapObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                        ObjectInspectorFactory.getStandardMapObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                            PrimitiveObjectInspectorFactory.javaFloatObjectInspector)),
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    ObjectInspectorFactory.getStandardMapObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaFloatObjectInspector),
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        "-l2 0.01 -l1 0.01")}, rows);
     }
 
 }

--- a/core/src/test/java/hivemall/regression/AdaGradUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/AdaGradUDTFTest.java
@@ -20,13 +20,17 @@ package hivemall.regression;
 
 import static org.junit.Assert.assertEquals;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.junit.Test;
+
+import java.util.Arrays;
 
 public class AdaGradUDTFTest {
 
@@ -56,5 +60,15 @@ public class AdaGradUDTFTest {
         StructObjectInspector longListSOI = udtf.initialize(new ObjectInspector[] {longListOI,
                 labelOI});
         assertEquals("struct<feature:bigint,weight:float>", longListSOI.getTypeName());
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            AdaGradUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaFloatObjectInspector}, new Object[][] {{
+                    Arrays.asList("1:-2", "2:-1"), 1.f}});
     }
 }

--- a/core/src/test/java/hivemall/regression/GeneralRegressorUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressorUDTFTest.java
@@ -165,7 +165,7 @@ public class GeneralRegressorUDTFTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIlleagalStringFeature() throws Exception {
+    public void testIllegalStringFeature() throws Exception {
         List<String> x = Arrays.asList("1:-2jjjj", "2:-1");
         ObjectInspector featureOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         testFeature(x, featureOI, String.class, String.class);

--- a/core/src/test/java/hivemall/regression/GeneralRegressorUDTFTest.java
+++ b/core/src/test/java/hivemall/regression/GeneralRegressorUDTFTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.Collector;
@@ -321,6 +322,19 @@ public class GeneralRegressorUDTFTest {
                 }
             }
         }
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            GeneralRegressorUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaFloatObjectInspector,
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        "-loss SquaredLoss")},
+            new Object[][] {{Arrays.asList("1:-2", "2:-1"), 10.f}});
     }
 
     private static void println(String msg) {

--- a/core/src/test/java/hivemall/smile/tools/TreePredictUDFv1Test.java
+++ b/core/src/test/java/hivemall/smile/tools/TreePredictUDFv1Test.java
@@ -20,6 +20,7 @@ package hivemall.smile.tools;
 
 import static org.junit.Assert.assertEquals;
 
+import hivemall.TestUtils;
 import hivemall.math.matrix.dense.RowMajorDenseMatrix2d;
 import hivemall.smile.classification.DecisionTree;
 import hivemall.smile.data.Attribute;
@@ -226,6 +227,54 @@ public class TreePredictUDFv1Test {
         DoubleWritable result = (DoubleWritable) udf.evaluate(arguments);
         udf.close();
         return result.get();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException, ParseException {
+        URL url = new URL(
+            "https://gist.githubusercontent.com/myui/ef17aabecf0c0c5bcb69/raw/aac0575b4d43072c6f3c82d9072fdefb61892694/cpu.arff");
+        InputStream is = new BufferedInputStream(url.openStream());
+
+        ArffParser arffParser = new ArffParser();
+        arffParser.setResponseIndex(6);
+        AttributeDataset data = arffParser.parse(is);
+        double[] datay = data.toArray(new double[data.size()]);
+        double[][] datax = data.toArray(new double[data.size()][]);
+
+        int n = datax.length;
+        int m = 3 * n / 4;
+        int[] index = Math.permutate(n);
+
+        double[][] trainx = new double[m][];
+        double[] trainy = new double[m];
+        for (int i = 0; i < m; i++) {
+            trainx[i] = datax[index[i]];
+            trainy[i] = datay[index[i]];
+        }
+
+        double[][] testx = new double[n - m][];
+        double[] testy = new double[n - m];
+        for (int i = m; i < n; i++) {
+            testx[i - m] = datax[index[i]];
+            testy[i - m] = datay[index[i]];
+        }
+
+        Attribute[] attrs = SmileExtUtils.convertAttributeTypes(data.attributes());
+        RegressionTree tree = new RegressionTree(attrs, new RowMajorDenseMatrix2d(trainx,
+            trainx[0].length), trainy, 20);
+        String opScript = tree.predictOpCodegen(StackMachine.SEP);
+
+        TestUtils.testGenericUDFSerialization(
+            TreePredictUDFv1.class,
+            new ObjectInspector[] {
+                    PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaBooleanObjectInspector, false)},
+            new Object[] {"model_id#1", ModelType.opscode.getId(), opScript,
+                    ArrayUtils.toList(testx[0])});
     }
 
     private static void debugPrint(String msg) {

--- a/core/src/test/java/hivemall/statistics/MovingAverageUDTFTest.java
+++ b/core/src/test/java/hivemall/statistics/MovingAverageUDTFTest.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.Collector;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
@@ -63,6 +64,17 @@ public class MovingAverageUDTFTest {
         udtf.process(new Object[] {7.f, null});
 
         Assert.assertEquals(Arrays.asList(1.d, 1.5d, 2.d, 3.d, 4.d, 5.d, 6.d), results);
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            MovingAverageUDTF.class,
+            new ObjectInspector[] {
+                    PrimitiveObjectInspectorFactory.javaFloatObjectInspector,
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaIntObjectInspector, 3)},
+            new Object[][] { {1.f}, {2.f}, {3.f}, {4.f}, {5.f}});
     }
 
 }

--- a/core/src/test/java/hivemall/tools/TryCastUDFTest.java
+++ b/core/src/test/java/hivemall/tools/TryCastUDFTest.java
@@ -18,15 +18,18 @@
  */
 package hivemall.tools;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Text;
@@ -53,6 +56,17 @@ public class TryCastUDFTest {
         Assert.assertEquals(WritableUtils.val("0.1", "1.1", "2.1"), result);
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            TryCastUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector, "array<string>")},
+            new Object[] {Arrays.asList(1.d, 2.d, 3.d)});
     }
 
 }

--- a/core/src/test/java/hivemall/tools/array/ArrayAppendUDFTest.java
+++ b/core/src/test/java/hivemall/tools/array/ArrayAppendUDFTest.java
@@ -18,9 +18,11 @@
  */
 package hivemall.tools.array;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -85,7 +87,7 @@ public class ArrayAppendUDFTest {
         ArrayAppendUDF udf = new ArrayAppendUDF();
 
         udf.initialize(new ObjectInspector[] {
-                ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector),
+                ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector});
 
         DeferredObject[] args = new DeferredObject[] {new GenericUDF.DeferredJavaObject(null),
@@ -96,6 +98,16 @@ public class ArrayAppendUDFTest {
         Assert.assertNull(result);
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            ArrayAppendUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector}, new Object[] {
+                    Arrays.asList(0.d, 1.d, 2.d), 3.d});
     }
 
 }

--- a/core/src/test/java/hivemall/tools/array/ArrayElementAtUDFTest.java
+++ b/core/src/test/java/hivemall/tools/array/ArrayElementAtUDFTest.java
@@ -18,9 +18,11 @@
  */
 package hivemall.tools.array;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
@@ -76,6 +78,16 @@ public class ArrayElementAtUDFTest {
         Assert.assertEquals(WritableUtils.val("s1"), udf.evaluate(args));
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            ArrayElementAtUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector},
+            new Object[] {Arrays.asList(0.d, 1.d, 2.d), 1});
     }
 
 }

--- a/core/src/test/java/hivemall/tools/array/ArrayFlattenUDFTest.java
+++ b/core/src/test/java/hivemall/tools/array/ArrayFlattenUDFTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
@@ -50,5 +51,14 @@ public class ArrayFlattenUDFTest {
         }
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            ArrayFlattenUDF.class,
+            new ObjectInspector[] {ObjectInspectorFactory.getStandardListObjectInspector(ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaIntObjectInspector))},
+            new Object[] {Arrays.asList(Arrays.asList(0, 1, 2, 3), Arrays.asList(4, 5),
+                Arrays.asList(6, 7))});
     }
 }

--- a/core/src/test/java/hivemall/tools/array/ArraySliceUDFTest.java
+++ b/core/src/test/java/hivemall/tools/array/ArraySliceUDFTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
@@ -109,5 +110,18 @@ public class ArraySliceUDFTest {
 
         udf.close();
 
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            ArraySliceUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector},
+            new Object[] {
+                    Arrays.asList("zero", "one", "two", "three", "four", "five", "six", "seven",
+                        "eight", "nine", "ten"), 2, 5});
     }
 }

--- a/core/src/test/java/hivemall/tools/array/ArrayUnionUDFTest.java
+++ b/core/src/test/java/hivemall/tools/array/ArrayUnionUDFTest.java
@@ -18,9 +18,11 @@
  */
 package hivemall.tools.array;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -58,4 +60,13 @@ public class ArrayUnionUDFTest {
         udf.close();
     }
 
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            ArrayUnionUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector)},
+            new Object[] {Arrays.asList(0.d, 1.d), Arrays.asList(2.d, 3.d)});
+    }
 }

--- a/core/src/test/java/hivemall/tools/array/ConditionalEmitUDTFTest.java
+++ b/core/src/test/java/hivemall/tools/array/ConditionalEmitUDTFTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.Collector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -65,4 +66,15 @@ public class ConditionalEmitUDTFTest {
         udtf.close();
     }
 
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            ConditionalEmitUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaBooleanObjectInspector),
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector)},
+            new Object[][] {
+                    {Arrays.asList(true, false, true), Arrays.asList("one", "two", "three")},
+                    {Arrays.asList(true, true, false), Arrays.asList("one", "two", "three")}});
+    }
 }

--- a/core/src/test/java/hivemall/tools/array/FirstElementUDFTest.java
+++ b/core/src/test/java/hivemall/tools/array/FirstElementUDFTest.java
@@ -18,9 +18,11 @@
  */
 package hivemall.tools.array;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
@@ -59,6 +61,14 @@ public class FirstElementUDFTest {
         Assert.assertNull(udf.evaluate(args));
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            FirstElementUDF.class,
+            new ObjectInspector[] {ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector)},
+            new Object[] {Arrays.asList(0.d, 1.d, 2.d)});
     }
 
 }

--- a/core/src/test/java/hivemall/tools/array/LastElementUDFTest.java
+++ b/core/src/test/java/hivemall/tools/array/LastElementUDFTest.java
@@ -18,9 +18,11 @@
  */
 package hivemall.tools.array;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
@@ -59,6 +61,14 @@ public class LastElementUDFTest {
         Assert.assertNull(udf.evaluate(args));
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            FirstElementUDF.class,
+            new ObjectInspector[] {ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector)},
+            new Object[] {Arrays.asList(0.d, 1.d, 2.d)});
     }
 
 }

--- a/core/src/test/java/hivemall/tools/array/SelectKBestUDFTest.java
+++ b/core/src/test/java/hivemall/tools/array/SelectKBestUDFTest.java
@@ -21,6 +21,7 @@ package hivemall.tools.array;
 import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -70,17 +71,22 @@ public class SelectKBestUDFTest {
     }
 
     @Test
-    public void testSerialization() throws HiveException {
-        final SelectKBestUDF selectKBest = new SelectKBestUDF();
+    public void testSerialization() throws HiveException, IOException {
         final int k = 2;
-        selectKBest.initialize(new ObjectInspector[] {
-                ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector),
-                ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector),
-                ObjectInspectorUtils.getConstantObjectInspector(
-                    PrimitiveObjectInspectorFactory.javaIntObjectInspector, k)});
+        final double[] data = new double[] {250.29999999999998, 170.90000000000003, 73.2,
+                12.199999999999996};
+        final double[] importanceList = new double[] {292.1666753739119, 152.70000455081467,
+                187.93333893418327, 59.93333511948589};
 
-        byte[] serialized = TestUtils.serializeObjectByKryo(selectKBest);
-        TestUtils.deserializeObjectByKryo(serialized, SelectKBestUDF.class);
+        TestUtils.testGenericUDFSerialization(
+            SelectKBestUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector),
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.writableDoubleObjectInspector),
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaIntObjectInspector, k)},
+            new Object[] {WritableUtils.toWritableList(data),
+                    WritableUtils.toWritableList(importanceList), k});
     }
 
 }

--- a/core/src/test/java/hivemall/tools/json/FromJsonUDFTest.java
+++ b/core/src/test/java/hivemall/tools/json/FromJsonUDFTest.java
@@ -18,11 +18,14 @@
  */
 package hivemall.tools.json;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.HiveUtils;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -78,5 +81,13 @@ public class FromJsonUDFTest {
         Assert.assertEquals(37, result.get(1));
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(FromJsonUDF.class,
+            new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                    HiveUtils.getConstStringObjectInspector("array<double>")},
+            new Object[] {"[0.1,1.1,2.2]"});
     }
 }

--- a/core/src/test/java/hivemall/tools/json/ToJsonUDFTest.java
+++ b/core/src/test/java/hivemall/tools/json/ToJsonUDFTest.java
@@ -18,8 +18,10 @@
  */
 package hivemall.tools.json;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF.DeferredObject;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -28,6 +30,9 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Arrays;
 
 public class ToJsonUDFTest {
 
@@ -45,6 +50,14 @@ public class ToJsonUDFTest {
         Assert.assertEquals("[0.1,1.1,2.1]", serialized.toString());
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            ToJsonUDF.class,
+            new ObjectInspector[] {ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector)},
+            new Object[] {Arrays.asList(0.1d, 1.1d, 2.1d)});
     }
 
 }

--- a/core/src/test/java/hivemall/tools/vector/VectorAddUDFTest.java
+++ b/core/src/test/java/hivemall/tools/vector/VectorAddUDFTest.java
@@ -18,6 +18,7 @@
  */
 package hivemall.tools.vector;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.io.IOException;
@@ -76,5 +77,15 @@ public class VectorAddUDFTest {
         Assert.assertEquals(expected, actual);
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            VectorAddUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaFloatObjectInspector)},
+            new Object[] {Arrays.asList(1.d, 2.d, 3.d), Arrays.asList(2.f, 3.f, 4.f)});
     }
 }

--- a/core/src/test/java/hivemall/tools/vector/VectorDotUDFTest.java
+++ b/core/src/test/java/hivemall/tools/vector/VectorDotUDFTest.java
@@ -18,6 +18,7 @@
  */
 package hivemall.tools.vector;
 
+import hivemall.TestUtils;
 import hivemall.utils.hadoop.WritableUtils;
 
 import java.io.IOException;
@@ -75,5 +76,15 @@ public class VectorDotUDFTest {
         Assert.assertEquals(expected, actual);
 
         udf.close();
+    }
+
+    @Test
+    public void testSerialization() throws HiveException, IOException {
+        TestUtils.testGenericUDFSerialization(
+            VectorDotUDF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaDoubleObjectInspector),
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaFloatObjectInspector)},
+            new Object[] {Arrays.asList(1.d, 2.d, 3.d), Arrays.asList(2.f, 3.f, 4.f)});
     }
 }

--- a/core/src/test/java/hivemall/topicmodel/LDAUDTFTest.java
+++ b/core/src/test/java/hivemall/topicmodel/LDAUDTFTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.Arrays;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -159,6 +160,21 @@ public class LDAUDTFTest {
         Assert.assertTrue("doc2 is in topic " + k2 + " (" + (topicDistr[k2] * 100) + "%), "
                 + "and `アボカド` SHOULD be more suitable topic word than `健康` in the topic",
             udtf.getWordScore("アボカド", k2) > udtf.getWordScore("健康", k2));
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            LDAUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        "-topics 2 -num_docs 2 -s 1 -iter 32 -eps 1e-3")},
+            new Object[][] {
+                    {Arrays.asList("fruits:1", "healthy:1", "vegetables:1")},
+                    {Arrays.asList("apples:1", "avocados:1", "colds:1", "flu:1", "like:2",
+                        "oranges:1")}});
     }
 
     private static void println(String msg) {

--- a/core/src/test/java/hivemall/topicmodel/PLSAUDTFTest.java
+++ b/core/src/test/java/hivemall/topicmodel/PLSAUDTFTest.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.Arrays;
 
+import hivemall.TestUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -160,6 +161,21 @@ public class PLSAUDTFTest {
         Assert.assertTrue("doc2 is in topic " + k2 + " (" + (topicDistr[k2] * 100) + "%), "
                 + "and `アボカド` SHOULD be more suitable topic word than `健康` in the topic",
             udtf.getWordScore("アボカド", k2) > udtf.getWordScore("健康", k2));
+    }
+
+    @Test
+    public void testSerialization() throws HiveException {
+        TestUtils.testGenericUDTFSerialization(
+            PLSAUDTF.class,
+            new ObjectInspector[] {
+                    ObjectInspectorFactory.getStandardListObjectInspector(PrimitiveObjectInspectorFactory.javaStringObjectInspector),
+                    ObjectInspectorUtils.getConstantObjectInspector(
+                        PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        "-topics 2 -alpha 0.1 -delta 0.00001 -iter 10000")},
+            new Object[][] {
+                    {Arrays.asList("fruits:1", "healthy:1", "vegetables:1")},
+                    {Arrays.asList("apples:1", "avocados:1", "colds:1", "flu:1", "like:2",
+                        "oranges:1")}});
     }
 
     private static void println(String msg) {

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -159,8 +159,7 @@ public final class KuromojiUDF extends GenericUDF {
     }
 
     @Nonnull
-    private static Mode tokenizationMode(@Nullable final String arg)
-            throws UDFArgumentException {
+    private static Mode tokenizationMode(@Nullable final String arg) throws UDFArgumentException {
         if (arg == null) {
             return Mode.NORMAL;
         }
@@ -194,8 +193,7 @@ public final class KuromojiUDF extends GenericUDF {
     }
 
     @Nonnull
-    private static Set<String> stopTags(@Nullable final String[] array)
-            throws UDFArgumentException {
+    private static Set<String> stopTags(@Nullable final String[] array) throws UDFArgumentException {
         if (array == null) {
             return JapaneseAnalyzer.getDefaultStopTags();
         }

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/KuromojiUDF.java
@@ -69,13 +69,10 @@ public final class KuromojiUDF extends GenericUDF {
     private static final int READ_TIMEOUT_MS = 60000; // 60 sec
     private static final long MAX_INPUT_STREAM_SIZE = 32L * 1024L * 1024L; // ~32MB
 
-    private Mode _mode;
-
-    // lazy instantiation to avoid org.apache.hive.com.esotericsoftware.kryo.KryoException: java.lang.NullPointerException
-    private transient CharArraySet _stopWords;
-
-    private Set<String> _stopTags;
-    private UserDictionary _userDict;
+    private String _modeString;
+    private String[] _stopWordsArray;
+    private String[] _stopTagsArray;
+    private Object _userDictObj;
 
     // workaround to avoid org.apache.hive.com.esotericsoftware.kryo.KryoException: java.util.ConcurrentModificationException
     private transient JapaneseAnalyzer _analyzer;
@@ -88,12 +85,29 @@ public final class KuromojiUDF extends GenericUDF {
                     + arglen);
         }
 
-        this._mode = (arglen >= 2) ? tokenizationMode(arguments[1]) : Mode.NORMAL;
-        this._stopWords = (arglen >= 3) ? stopWords(arguments[2])
-                : JapaneseAnalyzer.getDefaultStopSet();
-        this._stopTags = (arglen >= 4) ? stopTags(arguments[3])
-                : JapaneseAnalyzer.getDefaultStopTags();
-        this._userDict = (arglen >= 5) ? userDictionary(arguments[4]) : null;
+        this._modeString = (arglen >= 2) ? HiveUtils.getConstString(arguments[1]) : "NORMAL";
+
+        this._stopWordsArray = null;
+        if (arglen >= 3 && !HiveUtils.isVoidOI(arguments[2])) {
+            this._stopWordsArray = HiveUtils.getConstStringArray(arguments[2]);
+        }
+
+        this._stopTagsArray = null;
+        if (arglen >= 4 && !HiveUtils.isVoidOI(arguments[3])) {
+            this._stopTagsArray = HiveUtils.getConstStringArray(arguments[3]);
+        }
+
+        this._userDictObj = null;
+        if (arglen >= 5) {
+            if (HiveUtils.isConstListOI(arguments[4])) {
+                this._userDictObj = HiveUtils.getConstStringArray(arguments[4]);
+            } else if (HiveUtils.isConstString(arguments[4])) {
+                this._userDictObj = HiveUtils.getConstString(arguments[4]);
+            } else {
+                throw new UDFArgumentException(
+                    "User dictionary MUST be given as an array of constant string or constant string (URL)");
+            }
+        }
 
         this._analyzer = null;
 
@@ -103,7 +117,18 @@ public final class KuromojiUDF extends GenericUDF {
     @Override
     public List<Text> evaluate(DeferredObject[] arguments) throws HiveException {
         if (_analyzer == null) {
-            this._analyzer = new JapaneseAnalyzer(_userDict, _mode, _stopWords, _stopTags);
+            Mode mode = tokenizationMode(_modeString);
+            CharArraySet stopWords = stopWords(_stopWordsArray);
+            Set<String> stopTags = stopTags(_stopTagsArray);
+
+            UserDictionary userDict = null;
+            if (_userDictObj instanceof String[]) {
+                userDict = userDictionary((String[]) _userDictObj);
+            } else if (_userDictObj instanceof String) {
+                userDict = userDictionary((String) _userDictObj);
+            }
+
+            this._analyzer = new JapaneseAnalyzer(userDict, mode, stopWords, stopTags);
         }
 
         Object arg0 = arguments[0].get();
@@ -134,9 +159,8 @@ public final class KuromojiUDF extends GenericUDF {
     }
 
     @Nonnull
-    private static Mode tokenizationMode(@Nonnull final ObjectInspector oi)
+    private static Mode tokenizationMode(@Nullable final String arg)
             throws UDFArgumentException {
-        final String arg = HiveUtils.getConstString(oi);
         if (arg == null) {
             return Mode.NORMAL;
         }
@@ -157,12 +181,8 @@ public final class KuromojiUDF extends GenericUDF {
     }
 
     @Nonnull
-    private static CharArraySet stopWords(@Nonnull final ObjectInspector oi)
+    private static CharArraySet stopWords(@Nullable final String[] array)
             throws UDFArgumentException {
-        if (HiveUtils.isVoidOI(oi)) {
-            return JapaneseAnalyzer.getDefaultStopSet();
-        }
-        final String[] array = HiveUtils.getConstStringArray(oi);
         if (array == null) {
             return JapaneseAnalyzer.getDefaultStopSet();
         }
@@ -174,12 +194,8 @@ public final class KuromojiUDF extends GenericUDF {
     }
 
     @Nonnull
-    private static Set<String> stopTags(@Nonnull final ObjectInspector oi)
+    private static Set<String> stopTags(@Nullable final String[] array)
             throws UDFArgumentException {
-        if (HiveUtils.isVoidOI(oi)) {
-            return JapaneseAnalyzer.getDefaultStopTags();
-        }
-        final String[] array = HiveUtils.getConstStringArray(oi);
         if (array == null) {
             return JapaneseAnalyzer.getDefaultStopTags();
         }
@@ -195,19 +211,6 @@ public final class KuromojiUDF extends GenericUDF {
             }
         }
         return results;
-    }
-
-    @Nullable
-    private static UserDictionary userDictionary(@Nonnull final ObjectInspector oi)
-            throws UDFArgumentException {
-        if (HiveUtils.isConstListOI(oi)) {
-            return userDictionary(HiveUtils.getConstStringArray(oi));
-        } else if (HiveUtils.isConstString(oi)) {
-            return userDictionary(HiveUtils.getConstString(oi));
-        } else {
-            throw new UDFArgumentException(
-                "User dictionary MUST be given as an array of constant string or constant string (URL)");
-        }
     }
 
     @Nullable

--- a/nlp/src/main/java/hivemall/nlp/tokenizer/SmartcnUDF.java
+++ b/nlp/src/main/java/hivemall/nlp/tokenizer/SmartcnUDF.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
@@ -102,7 +103,7 @@ public final class SmartcnUDF extends GenericUDF {
     }
 
     @Nonnull
-    private static CharArraySet stopWords(@Nonnull final String[] array)
+    private static CharArraySet stopWords(@Nullable final String[] array)
             throws UDFArgumentException {
         if (array == null) {
             return SmartChineseAnalyzer.getDefaultStopSet();

--- a/nlp/src/test/java/hivemall/TestUtils.java
+++ b/nlp/src/test/java/hivemall/TestUtils.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall;
+
+import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hive.com.esotericsoftware.kryo.Kryo;
+import org.apache.hive.com.esotericsoftware.kryo.io.Input;
+import org.apache.hive.com.esotericsoftware.kryo.io.Output;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+
+public final class TestUtils {
+
+    @Nonnull
+    public static byte[] serializeObjectByKryo(@Nonnull Object obj) {
+        Kryo kryo = getKryo();
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        Output output = new Output(bos);
+        kryo.writeObject(output, obj);
+        output.close();
+        return bos.toByteArray();
+    }
+
+    @Nonnull
+    public static <T> T deserializeObjectByKryo(@Nonnull byte[] in, @Nonnull Class<T> clazz) {
+        Kryo kryo = getKryo();
+        Input inp = new Input(in);
+        T t = kryo.readObject(inp, clazz);
+        inp.close();
+        return t;
+    }
+
+    @Nonnull
+    private static Kryo getKryo() {
+        return Utilities.runtimeSerializationKryo.get();
+    }
+
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Kryo serialization test to existing workaround code as: https://github.com/apache/incubator-hivemall/commit/f6765dff7be67e1a3327709bbb9bfdc6eba7b97f

To be more precise, currently two UDFs `quantified_features` and `tokenize_ja` explicitly have the workaround lazy instantiation code. So, this PR makes their `transient` keyword unnecessary.

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-191

## How was this patch tested?

Added some unit tests, and manually tested as well

## Checklist

- [x] Did you apply source code formatter, i.e., `mvn formatter:format`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
