### PR TITLE
[HIVEMALL-203] Relocated org.codehaus.jackson to hivemall.codehause.jackson in hivemall-all.jar

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -54,6 +54,13 @@
 			<version>${project.version}</version>
 			<scope>compile</scope>
 		</dependency>
+		<!-- Jackson -->
+		<dependency>
+			<groupId>org.codehaus.jackson</groupId>
+			<artifactId>jackson-core-asl</artifactId>
+			<version>1.8.3</version>
+			<scope>compile</scope>
+		</dependency>
 	</dependencies>
 
 	<build>
@@ -113,11 +120,19 @@
 									<include>org.apache.hivemall:hivemall-xgboost</include>
 									<include>io.github.myui:xgboost4j</include>
 									<include>com.esotericsoftware.kryo:kryo</include>
+									<!-- Jackson -->
+									<include>org.codehaus.jackson:jackson-core-asl</include>
 								</includes>
 								<excludes>
 									<exclude>org.apache.hivemall:hivemall-all</exclude>
 								</excludes>
 							</artifactSet>
+							<relocations>
+								<relocation>
+									<pattern>org.codehaus.jackson</pattern>
+									<shadedPattern>hivemall.codehaus.jackson</shadedPattern>
+								</relocation>
+							</relocations>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<manifestEntries>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Relocated `org.codehaus.jackson` to `hivemall.codehause.jackson` in hivemall-all.jar because Jackson can be missing in some Hadoop/Hive enviroment

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-203

## How was this patch tested?

manual tests

## Checklist

(Please remove this section if not needed; check `x` for YES, blank for NO)

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
