### PR TITLE
[HIVEMALL-163] Add IS_INFINITE, IS_FINITE, IS_NAN functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ All Hivemall functions are defined under [resources/ddl](resources/ddl). In orde
 $ ./bin/update_ddls.sh
 ```
 
+Moreover, don't forget to update function list in the document as well:
+
+```
+$ ./bin/update_func_md.sh
+```
+
 Note that, before creating a pull request including Java code, please make sure your code follows our coding conventions by applying formatter:
 
 ```

--- a/core/src/main/java/hivemall/tools/math/InfinityUDF.java
+++ b/core/src/main/java/hivemall/tools/math/InfinityUDF.java
@@ -1,0 +1,12 @@
+package hivemall.tools.math;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+@Description(name = "infinity",
+        value = "_FUNC_() - Returns the constant representing positive infinity.")
+public final class InfinityUDF extends UDF {
+    public double evaluate() {
+        return Double.POSITIVE_INFINITY;
+    }
+}

--- a/core/src/main/java/hivemall/tools/math/InfinityUDF.java
+++ b/core/src/main/java/hivemall/tools/math/InfinityUDF.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.apache.hadoop.hive.ql.exec.Description;

--- a/core/src/main/java/hivemall/tools/math/IsFiniteUDF.java
+++ b/core/src/main/java/hivemall/tools/math/IsFiniteUDF.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.apache.hadoop.hive.ql.exec.Description;

--- a/core/src/main/java/hivemall/tools/math/IsFiniteUDF.java
+++ b/core/src/main/java/hivemall/tools/math/IsFiniteUDF.java
@@ -1,0 +1,15 @@
+package hivemall.tools.math;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+@Description(name = "is_finite", value = "_FUNC_(x) - Determine if x is infinite.")
+public final class IsFiniteUDF extends UDF {
+    public Boolean evaluate(Double num) {
+        if (num == null) {
+            return null;
+        } else {
+            return !num.isNaN() && !num.isInfinite();
+        }
+    }
+}

--- a/core/src/main/java/hivemall/tools/math/IsInfiniteUDF.java
+++ b/core/src/main/java/hivemall/tools/math/IsInfiniteUDF.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.apache.hadoop.hive.ql.exec.Description;

--- a/core/src/main/java/hivemall/tools/math/IsInfiniteUDF.java
+++ b/core/src/main/java/hivemall/tools/math/IsInfiniteUDF.java
@@ -27,7 +27,7 @@ public final class IsInfiniteUDF extends UDF {
         if (num == null) {
             return null;
         } else {
-            return !num.isNaN() && num.isInfinite();
+            return num.isInfinite();
         }
     }
 }

--- a/core/src/main/java/hivemall/tools/math/IsInfiniteUDF.java
+++ b/core/src/main/java/hivemall/tools/math/IsInfiniteUDF.java
@@ -1,0 +1,15 @@
+package hivemall.tools.math;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+@Description(name = "is_infinite", value = "_FUNC_(x) - Determine if x is infinite.")
+public final class IsInfiniteUDF extends UDF {
+    public Boolean evaluate(Double num) {
+        if (num == null) {
+            return null;
+        } else {
+            return !num.isNaN() && num.isInfinite();
+        }
+    }
+}

--- a/core/src/main/java/hivemall/tools/math/IsNanUDF.java
+++ b/core/src/main/java/hivemall/tools/math/IsNanUDF.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.apache.hadoop.hive.ql.exec.Description;

--- a/core/src/main/java/hivemall/tools/math/IsNanUDF.java
+++ b/core/src/main/java/hivemall/tools/math/IsNanUDF.java
@@ -1,0 +1,15 @@
+package hivemall.tools.math;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+@Description(name = "is_nan", value = "_FUNC_(x) - Determine if x is not-a-number.")
+public final class IsNanUDF extends UDF {
+    public Boolean evaluate(Double num) {
+        if (num == null) {
+            return null;
+        } else {
+            return num.isNaN(num);
+        }
+    }
+}

--- a/core/src/main/java/hivemall/tools/math/NanUDF.java
+++ b/core/src/main/java/hivemall/tools/math/NanUDF.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.apache.hadoop.hive.ql.exec.Description;

--- a/core/src/main/java/hivemall/tools/math/NanUDF.java
+++ b/core/src/main/java/hivemall/tools/math/NanUDF.java
@@ -1,0 +1,11 @@
+package hivemall.tools.math;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDF;
+
+@Description(name = "nan", value = "_FUNC_() - Returns the constant representing not-a-number.")
+public final class NanUDF extends UDF {
+    public double evaluate() {
+        return Double.NaN;
+    }
+}

--- a/core/src/test/java/hivemall/tools/math/InfinityUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/InfinityUDFTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.junit.Assert;

--- a/core/src/test/java/hivemall/tools/math/InfinityUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/InfinityUDFTest.java
@@ -1,0 +1,19 @@
+package hivemall.tools.math;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InfinityUDFTest {
+    private InfinityUDF udf;
+
+    @Before
+    public void setUp() {
+        this.udf = new InfinityUDF();
+    }
+
+    @Test
+    public void test() {
+        Assert.assertEquals(true, Double.isInfinite(udf.evaluate()));
+    }
+}

--- a/core/src/test/java/hivemall/tools/math/IsFiniteUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/IsFiniteUDFTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.junit.Assert;

--- a/core/src/test/java/hivemall/tools/math/IsFiniteUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/IsFiniteUDFTest.java
@@ -1,0 +1,35 @@
+package hivemall.tools.math;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IsFiniteUDFTest {
+
+    private IsFiniteUDF udf;
+
+    @Before
+    public void setUp() {
+        this.udf = new IsFiniteUDF();
+    }
+
+    @Test
+    public void testNull() {
+        Assert.assertEquals(null, udf.evaluate(null));
+    }
+
+    @Test
+    public void testDouble() {
+        Assert.assertEquals(true, udf.evaluate(1.0));
+    }
+
+    @Test
+    public void testInfinityNumber() {
+        Assert.assertEquals(false, udf.evaluate(Double.POSITIVE_INFINITY));
+    }
+
+    @Test
+    public void testNan() {
+        Assert.assertEquals(false, udf.evaluate(Double.NaN));
+    }
+}

--- a/core/src/test/java/hivemall/tools/math/IsInfiniteUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/IsInfiniteUDFTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.junit.Assert;

--- a/core/src/test/java/hivemall/tools/math/IsInfiniteUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/IsInfiniteUDFTest.java
@@ -1,0 +1,35 @@
+package hivemall.tools.math;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IsInfiniteUDFTest {
+    private IsInfiniteUDF udf;
+
+    @Before
+    public void setUp() {
+        this.udf = new IsInfiniteUDF();
+    }
+
+    @Test
+    public void testNull() {
+        Assert.assertEquals(null, udf.evaluate(null));
+    }
+
+    @Test
+    public void testDouble() {
+        Assert.assertEquals(false, udf.evaluate(1.0));
+    }
+
+    @Test
+    public void testInfinityNumber() {
+        Assert.assertEquals(true, udf.evaluate(Double.POSITIVE_INFINITY));
+    }
+
+    @Test
+    public void testNan() {
+        Assert.assertEquals(false, udf.evaluate(Double.NaN));
+    }
+
+}

--- a/core/src/test/java/hivemall/tools/math/IsNanUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/IsNanUDFTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.junit.Assert;

--- a/core/src/test/java/hivemall/tools/math/IsNanUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/IsNanUDFTest.java
@@ -1,0 +1,34 @@
+package hivemall.tools.math;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class IsNanUDFTest {
+    private IsNanUDF udf;
+
+    @Before
+    public void setUp() {
+        this.udf = new IsNanUDF();
+    }
+
+    @Test
+    public void testNull() {
+        Assert.assertEquals(null, udf.evaluate(null));
+    }
+
+    @Test
+    public void testDouble() {
+        Assert.assertEquals(false, udf.evaluate(1.0));
+    }
+
+    @Test
+    public void testNan() {
+        Assert.assertEquals(true, udf.evaluate(Double.NaN));
+    }
+
+    @Test
+    public void testInfinityNumber() {
+        Assert.assertEquals(false, udf.evaluate(Double.POSITIVE_INFINITY));
+    }
+}

--- a/core/src/test/java/hivemall/tools/math/NanUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/NanUDFTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package hivemall.tools.math;
 
 import org.junit.Assert;

--- a/core/src/test/java/hivemall/tools/math/NanUDFTest.java
+++ b/core/src/test/java/hivemall/tools/math/NanUDFTest.java
@@ -1,0 +1,19 @@
+package hivemall.tools.math;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+public class NanUDFTest {
+    private NanUDF udf;
+
+    @Before
+    public void setUp() {
+        this.udf = new NanUDF();
+    }
+
+    @Test
+    public void test() {
+        Assert.assertEquals(true, Double.isNaN(udf.evaluate()));
+    }
+}

--- a/docs/gitbook/misc/generic_funcs.md
+++ b/docs/gitbook/misc/generic_funcs.md
@@ -480,7 +480,17 @@ This page describes a list of useful Hivemall generic functions. See also a [lis
 
 # Math
 
+- `infinity()` - Returns the constant representing positive infinity.
+
+- `is_finite(x)` - Determine if x is infinite.
+
+- `is_infinite(x)` - Determine if x is infinite.
+
+- `is_nan(x)` - Determine if x is not-a-number.
+
 - `l2_norm(double xi)` - Return L2 norm of a vector which has the given values in each dimension
+
+- `nan()` - Returns the constant representing not-a-number.
 
 - `sigmoid(x)` - Returns 1.0 / (1.0 + exp(-x))
 

--- a/resources/ddl/define-all-as-permanent.hive
+++ b/resources/ddl/define-all-as-permanent.hive
@@ -530,6 +530,21 @@ CREATE FUNCTION sigmoid as 'hivemall.tools.math.SigmoidGenericUDF' USING JAR '${
 DROP FUNCTION IF EXISTS l2_norm;
 CREATE FUNCTION l2_norm as 'hivemall.tools.math.L2NormUDAF' USING JAR '${hivemall_jar}';
 
+DROP FUNCTION IF EXISTS infinity;
+CREATE FUNCTION infinity as 'hivemall.tools.math.InfinityUDF' USING JAR '${hivemall_jar}';
+
+DROP FUNCTION IF EXISTS is_infinite;
+CREATE FUNCTION is_infinite as 'hivemall.tools.math.IsInfiniteUDF' USING JAR '${hivemall_jar}';
+
+DROP FUNCTION IF EXISTS is_finite;
+CREATE FUNCTION is_finite as 'hivemall.tools.math.IsFiniteUDF' USING JAR '${hivemall_jar}';
+
+DROP FUNCTION IF EXISTS nan;
+CREATE FUNCTION nan as 'hivemall.tools.math.NanUDF' USING JAR '${hivemall_jar}';
+
+DROP FUNCTION IF EXISTS is_nan;
+CREATE FUNCTION is_nan as 'hivemall.tools.math.IsNanUDF' USING JAR '${hivemall_jar}';
+
 -----------------------------
 -- Matrix/Vector functions --
 -----------------------------

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -522,6 +522,21 @@ create temporary function sigmoid as 'hivemall.tools.math.SigmoidGenericUDF';
 drop temporary function if exists l2_norm;
 create temporary function l2_norm as 'hivemall.tools.math.L2NormUDAF';
 
+drop temporary function if exists infinity;
+create temporary function infinity as 'hivemall.tools.math.InfinityUDF';
+
+drop temporary function if exists is_infinite;
+create temporary function is_infinite as 'hivemall.tools.math.IsInfiniteUDF';
+
+drop temporary function if exists is_finite;
+create temporary function is_finite as 'hivemall.tools.math.IsFiniteUDF';
+
+drop temporary function if exists nan;
+create temporary function nan as 'hivemall.tools.math.NanUDF';
+
+drop temporary function if exists is_nan;
+create temporary function is_nan as 'hivemall.tools.math.IsNanUDF';
+
 -----------------------------
 -- Matrix/Vector functions --
 -----------------------------

--- a/resources/ddl/define-all.spark
+++ b/resources/ddl/define-all.spark
@@ -520,6 +520,21 @@ sqlContext.sql("CREATE TEMPORARY FUNCTION sigmoid AS 'hivemall.tools.math.Sigmoi
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS l2_norm")
 sqlContext.sql("CREATE TEMPORARY FUNCTION l2_norm AS 'hivemall.tools.math.L2NormUDAF'")
 
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS infinity")
+sqlContext.sql("CREATE TEMPORARY FUNCTION infinity AS 'hivemall.tools.math.InfinityUDF'")
+
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS is_infinite")
+sqlContext.sql("CREATE TEMPORARY FUNCTION is_infinite AS 'hivemall.tools.math.IsInfiniteUDF'")
+
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS is_finite")
+sqlContext.sql("CREATE TEMPORARY FUNCTION is_finite AS 'hivemall.tools.math.IsFiniteUDF'")
+
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS nan")
+sqlContext.sql("CREATE TEMPORARY FUNCTION nan AS 'hivemall.tools.math.NanUDF'")
+
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS is_nan")
+sqlContext.sql("CREATE TEMPORARY FUNCTION is_nan AS 'hivemall.tools.math.IsNanUDF'")
+
 /**
  * Matrix/Vector functions
  */


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add Floating point functions: infinity, is_finite, is_infinite, is_nan, nan

## What type of PR is it?

Feature

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-163

## How was this patch tested?

Unit tests

## How to use this feature?

```sql
select is_infinite(infinity());
select is_infinite(1.0);

select is_finite(infinity());
select is_finite(1.0);

select nan();

select is_nan(nan());
select is_nan(10.0);
```

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
