### PR TITLE
[HIVEMALL-196] Support BM25 scoring

### DIFF
--- a/core/src/main/java/hivemall/UDFWithOptions.java
+++ b/core/src/main/java/hivemall/UDFWithOptions.java
@@ -112,6 +112,30 @@ public abstract class UDFWithOptions extends GenericUDF {
         return cl;
     }
 
+    /**
+     * Raise {@link UDFArgumentException} if the given condition is false.
+     *
+     * @throws UDFArgumentException
+     */
+    protected static void assumeTrue(final boolean condition, @Nonnull final String errMsg)
+            throws UDFArgumentException {
+        if (!condition) {
+            throw new UDFArgumentException(errMsg);
+        }
+    }
+
+    /**
+     * Raise {@link UDFArgumentException} if the given condition is true.
+     *
+     * @throws UDFArgumentException
+     */
+    protected static void assumeFalse(final boolean condition, @Nonnull final String errMsg)
+            throws UDFArgumentException {
+        if (condition) {
+            throw new UDFArgumentException(errMsg);
+        }
+    }
+
     @Nonnull
     protected abstract CommandLine processOptions(@Nonnull String optionValue)
             throws UDFArgumentException;

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -144,7 +144,7 @@ public final class OkapiBM25UDF extends UDFWithOptions {
         }
 
         if (averageDocLength < 0.0) {
-            throw new UDFArgumentException("#averageDocLength cannot be negative");
+            throw new UDFArgumentException("#averageDocLength must be positive");
         }
 
         if (Math.abs(averageDocLength) < EPSILON) {

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -52,20 +52,21 @@ public final class OkapiBM25UDF extends UDFWithOptions {
     private PrimitiveObjectInspector numDocsWithWordOI;
 
 
-    public OkapiBM25UDF() {
-    }
+    public OkapiBM25UDF() {}
 
     @Nonnull
     @Override
     protected Options getOptions() {
         Options opts = new Options();
         opts.addOption("tf_word", "termFrequencyOfWordInDoc", false,
-                "Term frequency of a word in a document");
+            "Term frequency of a word in a document");
         opts.addOption("dl", "docLength", false, "Length of document in words");
         opts.addOption("avgdl", "averageDocLength", false, "Average length of documents in words");
         opts.addOption("N", "numDocs", false, "Number of documents");
-        opts.addOption("n", "numDocsWithWord", false, "Number of documents containing the word q_i");
-        opts.addOption("k_1", "k_1", true, "Hyperparameter with type double, usually in range 1.2 and 2.0 [default: 1.2]");
+        opts.addOption("n", "numDocsWithWord", false,
+            "Number of documents containing the word q_i");
+        opts.addOption("k_1", "k_1", true,
+            "Hyperparameter with type double, usually in range 1.2 and 2.0 [default: 1.2]");
         opts.addOption("b", "b", true, "Hyperparameter with type double [default: 0.75]");
         return opts;
     }
@@ -84,8 +85,7 @@ public final class OkapiBM25UDF extends UDFWithOptions {
     public ObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
         final int numArgOIs = argOIs.length;
         if (numArgOIs < 5) {
-            throw new UDFArgumentException(
-                    "argOIs.length must be greater than or equal to 5");
+            throw new UDFArgumentException("argOIs.length must be greater than or equal to 5");
         } else if (numArgOIs == 6) {
             String opts = HiveUtils.getConstString(argOIs[5]);
             processOptions(opts);
@@ -94,8 +94,8 @@ public final class OkapiBM25UDF extends UDFWithOptions {
         this.termFrequencyOI = HiveUtils.asDoubleOI(argOIs[0]);
         this.docLengthOI = HiveUtils.asIntegerOI(argOIs[1]);
         this.averageDocLengthOI = HiveUtils.asDoubleOI(argOIs[2]);
-        this.numDocsOI= HiveUtils.asIntegerOI(argOIs[3]);
-        this.numDocsWithWordOI= HiveUtils.asIntegerOI(argOIs[4]);
+        this.numDocsOI = HiveUtils.asIntegerOI(argOIs[3]);
+        this.numDocsWithWordOI = HiveUtils.asIntegerOI(argOIs[4]);
 
         return PrimitiveObjectInspectorFactory.writableDoubleObjectInspector;
     }
@@ -114,12 +114,14 @@ public final class OkapiBM25UDF extends UDFWithOptions {
         int numDocs = PrimitiveObjectInspectorUtils.getInt(arg3, numDocsOI);
         int numDocsWithWord = PrimitiveObjectInspectorUtils.getInt(arg4, numDocsWithWordOI);
 
-        double result = calculateBM25(termFrequency, docLength, averageDocLength, numDocs, numDocsWithWord);
+        double result =
+                calculateBM25(termFrequency, docLength, averageDocLength, numDocs, numDocsWithWord);
 
         return new DoubleWritable(result);
     }
 
-    private double calculateBM25(double termFrequency, int docLength, double averageDocLength, int numDocs, int numDocsWithWord) {
+    private double calculateBM25(double termFrequency, int docLength, double averageDocLength,
+            int numDocs, int numDocsWithWord) {
         double numerator = termFrequency * (k1 + 1);
         double denominator = termFrequency + k1 * (1 - b + b * docLength / averageDocLength);
         double idf = Math.log((numDocs - numDocsWithWord + 0.5) / (numDocsWithWord + 0.5));

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -27,7 +27,13 @@ import org.apache.hadoop.hive.ql.exec.UDAF;
 import org.apache.hadoop.hive.ql.exec.UDAFEvaluator;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import hivemall.utils.hadoop.HiveUtils;
+import org.apache.hadoop.hive.ql.udf.UDFType;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+import org.apache.hadoop.io.DoubleWritable;
 import org.apache.hadoop.io.FloatWritable;
 import org.apache.hadoop.io.Text;
 
@@ -38,10 +44,25 @@ import java.util.Map;
 
 @SuppressWarnings("deprecation")
 @Description(name = "okapi_bm25",
-        value = "_FUNC_(float tf_word, int dl, float avgdl, int N, int n [, const string options]) - Return an Okapi BM25 score in float")
+        value = "_FUNC_(double tf_word, int dl, double avgdl, int N, int n [, const string options]) - Return an Okapi BM25 score in float")
+//TODO: What does stateful mean?
+@UDFType(deterministic = true, stateful = false)
 public final class OkapiBM25UDF extends UDFWithOptions {
 
-    public OkapiBM25UDF() {}
+    private static final double DEFAULT_K1 = 1.2;
+    private static final double DEFAULT_B = 0.75;
+    private double k1 = DEFAULT_K1;
+    private double b = DEFAULT_B;
+
+    private PrimitiveObjectInspector termFrequencyOI;
+    private PrimitiveObjectInspector docLengthOI;
+    private PrimitiveObjectInspector averageDocLengthOI;
+    private PrimitiveObjectInspector numDocsOI;
+    private PrimitiveObjectInspector numDocsWithWordOI;
+
+
+    public OkapiBM25UDF() {
+    }
 
     @Nonnull
     @Override
@@ -53,25 +74,65 @@ public final class OkapiBM25UDF extends UDFWithOptions {
         opts.addOption("avgdl", "averageDocLength", false, "Average length of documents in words");
         opts.addOption("N", "numDocs", false, "Number of documents");
         opts.addOption("n", "numDocsWithWord", false, "Number of documents containing the word q_i");
-        opts.addOption("k_1", "k_1", true, "Hyperparameter usually in range 1.2 and 2.0 [default: 1.2]");
-        opts.addOption("b", "b", true, "Hyperparameter [default: 0.75]");
+        opts.addOption("k_1", "k_1", true, "Hyperparameter with type double, usually in range 1.2 and 2.0 [default: 1.2]");
+        opts.addOption("b", "b", true, "Hyperparameter with type double [default: 0.75]");
         return opts;
     }
 
     @Nonnull
     @Override
     protected CommandLine processOptions(@Nonnull String opts) throws UDFArgumentException {
-        return null;
+        CommandLine cl = parseOptions(opts);
+
+        this.k1 = Double.parseDouble(cl.getOptionValue("k1", Double.toString(DEFAULT_K1)));
+        this.b = Double.parseDouble(cl.getOptionValue("b", Double.toString(DEFAULT_B)));
+        return cl;
     }
 
     @Override
-    public ObjectInspector initialize(ObjectInspector[] objectInspectors) throws UDFArgumentException {
-        return null;
+    public ObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        final int numArgOIs = argOIs.length;
+        if (numArgOIs < 5) {
+            throw new UDFArgumentException(
+                    "argOIs.length must be greater than or equal to 5");
+        } else if (numArgOIs == 6) {
+            String opts = HiveUtils.getConstString(argOIs[5]);
+            processOptions(opts);
+        }
+
+        this.termFrequencyOI = HiveUtils.asDoubleOI(argOIs[0]);
+        this.docLengthOI = HiveUtils.asIntegerOI(argOIs[1]);
+        this.averageDocLengthOI = HiveUtils.asDoubleOI(argOIs[2]);
+        this.numDocsOI= HiveUtils.asIntegerOI(argOIs[3]);
+        this.numDocsWithWordOI= HiveUtils.asIntegerOI(argOIs[4]);
+
+        return PrimitiveObjectInspectorFactory.writableDoubleObjectInspector;
     }
 
     @Override
-    public Object evaluate(DeferredObject[] deferredObjects) throws HiveException {
-        return null;
+    public Object evaluate(DeferredObject[] arguments) throws HiveException {
+        Object arg0 = arguments[0].get();
+        Object arg1 = arguments[1].get();
+        Object arg2 = arguments[2].get();
+        Object arg3 = arguments[3].get();
+        Object arg4 = arguments[4].get();
+
+        double termFrequency = PrimitiveObjectInspectorUtils.getDouble(arg0, termFrequencyOI);
+        int docLength = PrimitiveObjectInspectorUtils.getInt(arg1, docLengthOI);
+        double averageDocLength = PrimitiveObjectInspectorUtils.getDouble(arg2, averageDocLengthOI);
+        int numDocs = PrimitiveObjectInspectorUtils.getInt(arg3, numDocsOI);
+        int numDocsWithWord = PrimitiveObjectInspectorUtils.getInt(arg4, numDocsWithWordOI);
+
+        double result = calculateBM25(termFrequency, docLength, averageDocLength, numDocs, numDocsWithWord);
+
+        return new DoubleWritable(result);
+    }
+
+    private double calculateBM25(double termFrequency, int docLength, double averageDocLength, int numDocs, int numDocsWithWord) {
+        double numerator = termFrequency * (k1 + 1);
+        double denominator = termFrequency + k1 * (1 - b + b * docLength / averageDocLength);
+        double idf = Math.log((numDocs - numDocsWithWord + 0.5) / (numDocsWithWord + 0.5));
+        return idf * numerator / denominator;
     }
 
     @Override

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -36,8 +36,7 @@ import javax.annotation.Nonnull;
 import java.util.Arrays;
 
 @Description(name = "okapi_bm25",
-        value = "_FUNC_(double tf_word, int dl, double avgdl, int N, int n [, const string options]) - Return an Okapi BM25 score in float")
-//TODO: What does stateful mean?
+        value = "_FUNC_(double tf_word, int dl, double avgdl, int N, int n [, const string options]) - Return an Okapi BM25 score in double")
 @UDFType(deterministic = true, stateful = false)
 public final class OkapiBM25UDF extends UDFWithOptions {
 

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -161,7 +161,7 @@ public final class OkapiBM25UDF extends UDFWithOptions {
     }
 
     @Override
-    public String getDisplayString(String[] strings) {
-        return null;
+    public String getDisplayString(String[] children) {
+        return "okapi_bm25(" + Arrays.toString(children) + ")";
     }
 }

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -19,12 +19,9 @@
 package hivemall.ftvec.text;
 
 import hivemall.UDFWithOptions;
-import hivemall.utils.lang.mutable.MutableInt;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.Options;
 import org.apache.hadoop.hive.ql.exec.Description;
-import org.apache.hadoop.hive.ql.exec.UDAF;
-import org.apache.hadoop.hive.ql.exec.UDAFEvaluator;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import hivemall.utils.hadoop.HiveUtils;
@@ -34,13 +31,9 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 import org.apache.hadoop.io.DoubleWritable;
-import org.apache.hadoop.io.FloatWritable;
-import org.apache.hadoop.io.Text;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.HashMap;
-import java.util.Map;
 
 @SuppressWarnings("deprecation")
 @Description(name = "okapi_bm25",

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -33,9 +33,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.io.DoubleWritable;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-@SuppressWarnings("deprecation")
 @Description(name = "okapi_bm25",
         value = "_FUNC_(double tf_word, int dl, double avgdl, int N, int n [, const string options]) - Return an Okapi BM25 score in float")
 //TODO: What does stateful mean?

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -36,7 +36,7 @@ import javax.annotation.Nonnull;
 import java.util.Arrays;
 
 @Description(name = "okapi_bm25",
-        value = "_FUNC_(double tf_word, int dl, double avgdl, int N, int n [, const string options]) - Return an Okapi BM25 score in double")
+        value = "_FUNC_(int f, int dl, double avgdl, int N, int n [, const string options]) - Return an Okapi BM25 score in double")
 @UDFType(deterministic = true, stateful = false)
 public final class OkapiBM25UDF extends UDFWithOptions {
 
@@ -46,7 +46,7 @@ public final class OkapiBM25UDF extends UDFWithOptions {
     private double k1 = DEFAULT_K1;
     private double b = DEFAULT_B;
 
-    private PrimitiveObjectInspector termFrequencyOI;
+    private PrimitiveObjectInspector frequencyOI;
     private PrimitiveObjectInspector docLengthOI;
     private PrimitiveObjectInspector averageDocLengthOI;
     private PrimitiveObjectInspector numDocsOI;
@@ -59,8 +59,8 @@ public final class OkapiBM25UDF extends UDFWithOptions {
     @Override
     protected Options getOptions() {
         Options opts = new Options();
-        opts.addOption("tf_word", "termFrequencyOfWordInDoc", false,
-            "Term frequency of a word in a document");
+        opts.addOption("f", "frequencyOfTermInDoc", false,
+            "Raw frequency of a word in a document");
         opts.addOption("dl", "docLength", false, "Length of document in words");
         opts.addOption("avgdl", "averageDocLength", false, "Average length of documents in words");
         opts.addOption("N", "numDocs", false, "Number of documents");
@@ -92,7 +92,7 @@ public final class OkapiBM25UDF extends UDFWithOptions {
             processOptions(opts);
         }
 
-        this.termFrequencyOI = HiveUtils.asDoubleOI(argOIs[0]);
+        this.frequencyOI = HiveUtils.asIntegerOI(argOIs[0]);
         this.docLengthOI = HiveUtils.asIntegerOI(argOIs[1]);
         this.averageDocLengthOI = HiveUtils.asDoubleOI(argOIs[2]);
         this.numDocsOI = HiveUtils.asIntegerOI(argOIs[3]);
@@ -113,14 +113,14 @@ public final class OkapiBM25UDF extends UDFWithOptions {
             throw new UDFArgumentException("Required arguments cannot be null");
         }
 
-        double termFrequency = PrimitiveObjectInspectorUtils.getDouble(arg0, termFrequencyOI);
+        int frequency = PrimitiveObjectInspectorUtils.getInt(arg0, frequencyOI);
         int docLength = PrimitiveObjectInspectorUtils.getInt(arg1, docLengthOI);
         double averageDocLength = PrimitiveObjectInspectorUtils.getDouble(arg2, averageDocLengthOI);
         int numDocs = PrimitiveObjectInspectorUtils.getInt(arg3, numDocsOI);
         int numDocsWithWord = PrimitiveObjectInspectorUtils.getInt(arg4, numDocsWithWordOI);
 
-        if (termFrequency < 0.0) {
-            throw new UDFArgumentException("#termFrequency must be positive");
+        if (frequency < 0) {
+            throw new UDFArgumentException("#frequency must be positive");
         }
 
         if (docLength < 1) {
@@ -145,15 +145,15 @@ public final class OkapiBM25UDF extends UDFWithOptions {
 
 
         double result =
-                calculateBM25(termFrequency, docLength, averageDocLength, numDocs, numDocsWithWord);
+                calculateBM25(frequency, docLength, averageDocLength, numDocs, numDocsWithWord);
 
         return new DoubleWritable(result);
     }
 
-    private double calculateBM25(double termFrequency, int docLength, double averageDocLength,
+    private double calculateBM25(int frequency, int docLength, double averageDocLength,
             int numDocs, int numDocsWithWord) {
-        double numerator = termFrequency * (k1 + 1);
-        double denominator = termFrequency + k1 * (1 - b + b * docLength / averageDocLength);
+        double numerator = frequency * (k1 + 1);
+        double denominator = frequency + k1 * (1 - b + b * docLength / averageDocLength);
         double idf = Math.log10((numDocs - numDocsWithWord + 0.5) / (numDocsWithWord + 0.5));
         return idf * numerator / denominator;
     }

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 
 @Description(name = "bm25",
-        value = "_FUNC_(int termFrequency, int docLength, double avgDocLength, int numDocs, int numDocsWithTerm [, const string options]) - Return an Okapi BM25 score in double")
+        value = "_FUNC_(double termFrequency, int docLength, double avgDocLength, int numDocs, int numDocsWithTerm [, const string options]) - Return an Okapi BM25 score in double")
 @UDFType(deterministic = true, stateful = false)
 public final class OkapiBM25UDF extends UDFWithOptions {
 
@@ -114,9 +114,9 @@ public final class OkapiBM25UDF extends UDFWithOptions {
             processOptions(opts);
         }
 
-        this.frequencyOI = HiveUtils.asIntegerOI(argOIs[0]);
+        this.frequencyOI = HiveUtils.asDoubleCompatibleOI(argOIs[0]);
         this.docLengthOI = HiveUtils.asIntegerOI(argOIs[1]);
-        this.averageDocLengthOI = HiveUtils.asDoubleOI(argOIs[2]);
+        this.averageDocLengthOI = HiveUtils.asDoubleCompatibleOI(argOIs[2]);
         this.numDocsOI = HiveUtils.asIntegerOI(argOIs[3]);
         this.numDocsWithTermOI = HiveUtils.asIntegerOI(argOIs[4]);
 
@@ -135,7 +135,7 @@ public final class OkapiBM25UDF extends UDFWithOptions {
             throw new UDFArgumentException("Required arguments cannot be null");
         }
 
-        int frequency = PrimitiveObjectInspectorUtils.getInt(arg0, frequencyOI);
+        double frequency = PrimitiveObjectInspectorUtils.getDouble(arg0, frequencyOI);
         int docLength = PrimitiveObjectInspectorUtils.getInt(arg1, docLengthOI);
         double averageDocLength = PrimitiveObjectInspectorUtils.getDouble(arg2, averageDocLengthOI);
         int numDocs = PrimitiveObjectInspectorUtils.getInt(arg3, numDocsOI);
@@ -152,7 +152,7 @@ public final class OkapiBM25UDF extends UDFWithOptions {
         return result;
     }
 
-    private double bm25(final int tf, final int docLength, final double averageDocLength,
+    private double bm25(final double tf, final int docLength, final double averageDocLength,
             final int numDocs, final int numDocsWithTerm) {
         double numerator = tf * (k1 + 1);
         double denominator = tf + k1 * (1 - b + b * docLength / averageDocLength);

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.ftvec.text;
+
+import hivemall.UDFWithOptions;
+import hivemall.utils.lang.mutable.MutableInt;
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Options;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.UDAF;
+import org.apache.hadoop.hive.ql.exec.UDAFEvaluator;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.Text;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+@SuppressWarnings("deprecation")
+@Description(name = "okapi_bm25",
+        value = "_FUNC_(float tf_word, int dl, float avgdl, int N, int n [, const string options]) - Return an Okapi BM25 score in float")
+public final class OkapiBM25UDF extends UDFWithOptions {
+
+    public OkapiBM25UDF() {}
+
+    @Nonnull
+    @Override
+    protected Options getOptions() {
+        Options opts = new Options();
+        opts.addOption("tf_word", "termFrequencyOfWordInDoc", false,
+                "Term frequency of a word in a document");
+        opts.addOption("dl", "docLength", false, "Length of document in words");
+        opts.addOption("avgdl", "averageDocLength", false, "Average length of documents in words");
+        opts.addOption("N", "numDocs", false, "Number of documents");
+        opts.addOption("n", "numDocsWithWord", false, "Number of documents containing the word q_i");
+        opts.addOption("k_1", "k_1", true, "Hyperparameter usually in range 1.2 and 2.0 [default: 1.2]");
+        opts.addOption("b", "b", true, "Hyperparameter [default: 0.75]");
+        return opts;
+    }
+
+    @Nonnull
+    @Override
+    protected CommandLine processOptions(@Nonnull String opts) throws UDFArgumentException {
+        return null;
+    }
+
+    @Override
+    public ObjectInspector initialize(ObjectInspector[] objectInspectors) throws UDFArgumentException {
+        return null;
+    }
+
+    @Override
+    public Object evaluate(DeferredObject[] deferredObjects) throws HiveException {
+        return null;
+    }
+
+    @Override
+    public String getDisplayString(String[] strings) {
+        return null;
+    }
+}

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -154,8 +154,12 @@ public final class OkapiBM25UDF extends UDFWithOptions {
             int numDocs, int numDocsWithWord) {
         double numerator = frequency * (k1 + 1);
         double denominator = frequency + k1 * (1 - b + b * docLength / averageDocLength);
-        double idf = Math.log10((numDocs - numDocsWithWord + 0.5) / (numDocsWithWord + 0.5));
+        double idf = calculateIDF(numDocs, numDocsWithWord);
         return idf * numerator / denominator;
+    }
+
+    private static double calculateIDF(int numDocs, int numDocsWithWord) {
+        return Math.log10(1.0 + (numDocs - numDocsWithWord + 0.5) / (numDocsWithWord + 0.5));
     }
 
     @Override

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -45,6 +45,8 @@ public final class OkapiBM25UDF extends UDFWithOptions {
     private static final double DEFAULT_B = 0.75;
     private double k1 = DEFAULT_K1;
     private double b = DEFAULT_B;
+    private static final String K1_OPT_NAME = "k1";
+    private static final String B_OPT_NAME = "b";
 
     private PrimitiveObjectInspector frequencyOI;
     private PrimitiveObjectInspector docLengthOI;
@@ -66,9 +68,9 @@ public final class OkapiBM25UDF extends UDFWithOptions {
         opts.addOption("N", "numDocs", false, "Number of documents");
         opts.addOption("n", "numDocsWithWord", false,
             "Number of documents containing the word q_i");
-        opts.addOption("k1", "k1", true,
+        opts.addOption(K1_OPT_NAME, "k1", true,
             "Hyperparameter with type double, usually in range 1.2 and 2.0 [default: 1.2]");
-        opts.addOption("b", "b", true, "Hyperparameter with type double [default: 0.75]");
+        opts.addOption(B_OPT_NAME, "b", true, "Hyperparameter with type double in range 0.0 and 1.0 [default: 0.75]");
         return opts;
     }
 
@@ -77,8 +79,18 @@ public final class OkapiBM25UDF extends UDFWithOptions {
     protected CommandLine processOptions(@Nonnull String opts) throws UDFArgumentException {
         CommandLine cl = parseOptions(opts);
 
-        k1 = Double.parseDouble(cl.getOptionValue("k1", Double.toString(DEFAULT_K1)));
-        b = Double.parseDouble(cl.getOptionValue("b", Double.toString(DEFAULT_B)));
+        double k1Option = Double.parseDouble(cl.getOptionValue(K1_OPT_NAME, Double.toString(DEFAULT_K1)));
+        if (k1Option < 0.0) {
+            throw new UDFArgumentException(String.format("#%s hyperparameter must be positive", K1_OPT_NAME));
+        }
+        k1 = k1Option;
+
+        double bOption= Double.parseDouble(cl.getOptionValue(B_OPT_NAME, Double.toString(DEFAULT_B)));
+        if (bOption < 0.0 || bOption > 1.0) {
+            throw new UDFArgumentException(String.format("#%s hyperparameter must be in the range [0.0, 1.0]", B_OPT_NAME));
+        }
+        b = bOption;
+
         return cl;
     }
 

--- a/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
+++ b/core/src/main/java/hivemall/ftvec/text/OkapiBM25UDF.java
@@ -61,8 +61,7 @@ public final class OkapiBM25UDF extends UDFWithOptions {
     @Override
     protected Options getOptions() {
         Options opts = new Options();
-        opts.addOption("f", "frequencyOfTermInDoc", false,
-            "Raw frequency of a word in a document");
+        opts.addOption("f", "frequencyOfTermInDoc", false, "Raw frequency of a word in a document");
         opts.addOption("dl", "docLength", false, "Length of document in words");
         opts.addOption("avgdl", "averageDocLength", false, "Average length of documents in words");
         opts.addOption("N", "numDocs", false, "Number of documents");
@@ -70,7 +69,8 @@ public final class OkapiBM25UDF extends UDFWithOptions {
             "Number of documents containing the word q_i");
         opts.addOption(K1_OPT_NAME, "k1", true,
             "Hyperparameter with type double, usually in range 1.2 and 2.0 [default: 1.2]");
-        opts.addOption(B_OPT_NAME, "b", true, "Hyperparameter with type double in range 0.0 and 1.0 [default: 0.75]");
+        opts.addOption(B_OPT_NAME, "b", true,
+            "Hyperparameter with type double in range 0.0 and 1.0 [default: 0.75]");
         return opts;
     }
 
@@ -79,15 +79,19 @@ public final class OkapiBM25UDF extends UDFWithOptions {
     protected CommandLine processOptions(@Nonnull String opts) throws UDFArgumentException {
         CommandLine cl = parseOptions(opts);
 
-        double k1Option = Double.parseDouble(cl.getOptionValue(K1_OPT_NAME, Double.toString(DEFAULT_K1)));
+        double k1Option =
+                Double.parseDouble(cl.getOptionValue(K1_OPT_NAME, Double.toString(DEFAULT_K1)));
         if (k1Option < 0.0) {
-            throw new UDFArgumentException(String.format("#%s hyperparameter must be positive", K1_OPT_NAME));
+            throw new UDFArgumentException(
+                String.format("#%s hyperparameter must be positive", K1_OPT_NAME));
         }
         k1 = k1Option;
 
-        double bOption= Double.parseDouble(cl.getOptionValue(B_OPT_NAME, Double.toString(DEFAULT_B)));
+        double bOption =
+                Double.parseDouble(cl.getOptionValue(B_OPT_NAME, Double.toString(DEFAULT_B)));
         if (bOption < 0.0 || bOption > 1.0) {
-            throw new UDFArgumentException(String.format("#%s hyperparameter must be in the range [0.0, 1.0]", B_OPT_NAME));
+            throw new UDFArgumentException(
+                String.format("#%s hyperparameter must be in the range [0.0, 1.0]", B_OPT_NAME));
         }
         b = bOption;
 
@@ -162,8 +166,8 @@ public final class OkapiBM25UDF extends UDFWithOptions {
         return new DoubleWritable(result);
     }
 
-    private double calculateBM25(int frequency, int docLength, double averageDocLength,
-            int numDocs, int numDocsWithWord) {
+    private double calculateBM25(int frequency, int docLength, double averageDocLength, int numDocs,
+            int numDocsWithWord) {
         double numerator = frequency * (k1 + 1);
         double denominator = frequency + k1 * (1 - b + b * docLength / averageDocLength);
         double idf = calculateIDF(numDocs, numDocsWithWord);

--- a/core/src/main/java/hivemall/utils/lang/Primitives.java
+++ b/core/src/main/java/hivemall/utils/lang/Primitives.java
@@ -78,6 +78,10 @@ public final class Primitives {
         return v.doubleValue();
     }
 
+    public static boolean isFinite(final double value) {
+        return Double.NEGATIVE_INFINITY < value && value < Double.POSITIVE_INFINITY;
+    }
+
     public static int compare(final int x, final int y) {
         return (x < y) ? -1 : ((x == y) ? 0 : 1);
     }

--- a/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
@@ -60,7 +60,7 @@ public class OkapiBM25UDFTest {
                 VALID_NUM_DOCS_WITH_WORD
         };
 
-        DoubleWritable expected = WritableUtils.val(0.727425937348);
+        DoubleWritable expected = WritableUtils.val(0.940637195691);
         DoubleWritable actual = udf.evaluate(args);
         assertEquals(expected.get(), actual.get(), EPSILON);
     }
@@ -85,13 +85,13 @@ public class OkapiBM25UDFTest {
                 VALID_NUM_DOCS_WITH_WORD
         };
 
-        DoubleWritable expected = WritableUtils.val(0.775227505584);
+        DoubleWritable expected = WritableUtils.val(1.00244958206);
         DoubleWritable actual = udf.evaluate(args);
         assertEquals(expected.get(), actual.get(), EPSILON);
     }
 
     @Test
-    public void testEvaluateWithCustomK1AndB() throws Exception {
+    public void testEvaluateWithCustomB() throws Exception {
 
         udf.initialize(new ObjectInspector[] {
                 PrimitiveObjectInspectorFactory.javaIntObjectInspector,
@@ -110,7 +110,7 @@ public class OkapiBM25UDFTest {
                 VALID_NUM_DOCS_WITH_WORD
         };
 
-        DoubleWritable expected = WritableUtils.val(0.728823042222);
+        DoubleWritable expected = WritableUtils.val(0.942443797219);
         DoubleWritable actual = udf.evaluate(args);
         assertEquals(expected.get(), actual.get(), EPSILON);
     }

--- a/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
@@ -176,6 +176,51 @@ public class OkapiBM25UDFTest {
         udf.evaluate(args);
     }
 
+    @Test(expected = HiveException.class)
+    public void testAvgDocLengthIsZero() throws Exception {
+        initializeUDFWithoutOptions();
+
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
+                VALID_TERM_FREQ,
+                VALID_DOC_LEN,
+                new GenericUDF.DeferredJavaObject(new Double(0.0)),
+                VALID_NUM_DOCS,
+                VALID_NUM_DOCS_WITH_WORD
+        };
+
+        udf.evaluate(args);
+    }
+
+    @Test(expected = HiveException.class)
+    public void testNumDocsIsLessThanOne() throws Exception {
+        initializeUDFWithoutOptions();
+
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
+                VALID_TERM_FREQ,
+                VALID_DOC_LEN,
+                VALID_AVG_DOC_LEN,
+                new GenericUDF.DeferredJavaObject(new Integer(0)),
+                VALID_NUM_DOCS_WITH_WORD
+        };
+
+        udf.evaluate(args);
+    }
+
+    @Test(expected = HiveException.class)
+    public void testNumDocsWithWordIsLessThanOne() throws Exception {
+        initializeUDFWithoutOptions();
+
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
+                VALID_TERM_FREQ,
+                VALID_DOC_LEN,
+                VALID_AVG_DOC_LEN,
+                VALID_NUM_DOCS,
+                new GenericUDF.DeferredJavaObject(new Integer(0))
+        };
+
+        udf.evaluate(args);
+    }
+
     private void initializeUDFWithoutOptions() throws Exception {
         udf.initialize(new ObjectInspector[] {
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,

--- a/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
@@ -41,7 +41,7 @@ public class OkapiBM25UDFTest {
             new GenericUDF.DeferredJavaObject(new Double(10.35));
     private static final GenericUDF.DeferredJavaObject VALID_NUM_DOCS =
             new GenericUDF.DeferredJavaObject(new Integer(20));
-    private static final GenericUDF.DeferredJavaObject VALID_NUM_DOCS_WITH_WORD =
+    private static final GenericUDF.DeferredJavaObject VALID_NUM_DOCS_WITH_TERM =
             new GenericUDF.DeferredJavaObject(new Integer(5));
 
     private OkapiBM25UDF udf = null;
@@ -58,7 +58,7 @@ public class OkapiBM25UDFTest {
         initializeUDFWithoutOptions();
 
         GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
-                VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
+                VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_TERM};
 
         DoubleWritable expected = WritableUtils.val(0.940637195691);
         DoubleWritable actual = udf.evaluate(args);
@@ -77,7 +77,7 @@ public class OkapiBM25UDFTest {
                     HiveUtils.getConstStringObjectInspector("-k1 1.5")});
 
         GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
-                VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
+                VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_TERM};
 
         DoubleWritable expected = WritableUtils.val(1.00244958206);
         DoubleWritable actual = udf.evaluate(args);
@@ -96,7 +96,7 @@ public class OkapiBM25UDFTest {
                     HiveUtils.getConstStringObjectInspector("-b 0.8")});
 
         GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
-                VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
+                VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_TERM};
 
         DoubleWritable expected = WritableUtils.val(0.942443797219);
         DoubleWritable actual = udf.evaluate(args);
@@ -110,7 +110,7 @@ public class OkapiBM25UDFTest {
 
         GenericUDF.DeferredObject[] args =
                 new GenericUDF.DeferredObject[] {new GenericUDF.DeferredJavaObject(null),
-                        VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
+                        VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_TERM};
 
         udf.evaluate(args);
     }
@@ -121,7 +121,7 @@ public class OkapiBM25UDFTest {
 
         GenericUDF.DeferredObject[] args =
                 new GenericUDF.DeferredObject[] {new GenericUDF.DeferredJavaObject(new Integer(-1)),
-                        VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
+                        VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_TERM};
 
         udf.evaluate(args);
     }
@@ -132,7 +132,7 @@ public class OkapiBM25UDFTest {
 
         GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
                 new GenericUDF.DeferredJavaObject(new Integer(0)), VALID_AVG_DOC_LEN,
-                VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
+                VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_TERM};
 
         udf.evaluate(args);
     }
@@ -143,7 +143,7 @@ public class OkapiBM25UDFTest {
 
         GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
                 VALID_DOC_LEN, new GenericUDF.DeferredJavaObject(new Double(-10)), VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD};
+                VALID_NUM_DOCS_WITH_TERM};
 
         udf.evaluate(args);
     }
@@ -154,7 +154,7 @@ public class OkapiBM25UDFTest {
 
         GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
                 VALID_DOC_LEN, new GenericUDF.DeferredJavaObject(new Double(0.0)), VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD};
+                VALID_NUM_DOCS_WITH_TERM};
 
         udf.evaluate(args);
     }
@@ -165,13 +165,13 @@ public class OkapiBM25UDFTest {
 
         GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
                 VALID_DOC_LEN, VALID_AVG_DOC_LEN, new GenericUDF.DeferredJavaObject(new Integer(0)),
-                VALID_NUM_DOCS_WITH_WORD};
+                VALID_NUM_DOCS_WITH_TERM};
 
         udf.evaluate(args);
     }
 
     @Test(expected = HiveException.class)
-    public void testNumDocsWithWordIsLessThanOne() throws Exception {
+    public void testNumDocsWithTermIsLessThanOne() throws Exception {
         initializeUDFWithoutOptions();
 
         GenericUDF.DeferredObject[] args =

--- a/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.hadoop.WritableUtils;
+
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;

--- a/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
@@ -33,14 +33,19 @@ import org.junit.Test;
 public class OkapiBM25UDFTest {
 
     private static final double EPSILON = 1e-8;
-    private static final GenericUDF.DeferredJavaObject VALID_TERM_FREQ = new GenericUDF.DeferredJavaObject(new Integer(3));
-    private static final GenericUDF.DeferredJavaObject VALID_DOC_LEN = new GenericUDF.DeferredJavaObject(new Integer(9));
-    private static final GenericUDF.DeferredJavaObject VALID_AVG_DOC_LEN = new GenericUDF.DeferredJavaObject(new Double(10.35));
-    private static final GenericUDF.DeferredJavaObject VALID_NUM_DOCS = new GenericUDF.DeferredJavaObject(new Integer(20));
-    private static final GenericUDF.DeferredJavaObject VALID_NUM_DOCS_WITH_WORD = new GenericUDF.DeferredJavaObject(new Integer(5));
+    private static final GenericUDF.DeferredJavaObject VALID_TERM_FREQ =
+            new GenericUDF.DeferredJavaObject(new Integer(3));
+    private static final GenericUDF.DeferredJavaObject VALID_DOC_LEN =
+            new GenericUDF.DeferredJavaObject(new Integer(9));
+    private static final GenericUDF.DeferredJavaObject VALID_AVG_DOC_LEN =
+            new GenericUDF.DeferredJavaObject(new Double(10.35));
+    private static final GenericUDF.DeferredJavaObject VALID_NUM_DOCS =
+            new GenericUDF.DeferredJavaObject(new Integer(20));
+    private static final GenericUDF.DeferredJavaObject VALID_NUM_DOCS_WITH_WORD =
+            new GenericUDF.DeferredJavaObject(new Integer(5));
 
     private OkapiBM25UDF udf = null;
-    
+
 
     @Before
     public void init() throws Exception {
@@ -52,13 +57,8 @@ public class OkapiBM25UDFTest {
 
         initializeUDFWithoutOptions();
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                VALID_TERM_FREQ,
-                VALID_DOC_LEN,
-                VALID_AVG_DOC_LEN,
-                VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD
-        };
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
+                VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
 
         DoubleWritable expected = WritableUtils.val(0.940637195691);
         DoubleWritable actual = udf.evaluate(args);
@@ -68,22 +68,16 @@ public class OkapiBM25UDFTest {
     @Test
     public void testEvaluateWithCustomK1() throws Exception {
 
-        udf.initialize(new ObjectInspector[] {
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                HiveUtils.getConstStringObjectInspector("-k1 1.5")
-        });
+        udf.initialize(
+            new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    HiveUtils.getConstStringObjectInspector("-k1 1.5")});
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                VALID_TERM_FREQ,
-                VALID_DOC_LEN,
-                VALID_AVG_DOC_LEN,
-                VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD
-        };
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
+                VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
 
         DoubleWritable expected = WritableUtils.val(1.00244958206);
         DoubleWritable actual = udf.evaluate(args);
@@ -93,22 +87,16 @@ public class OkapiBM25UDFTest {
     @Test
     public void testEvaluateWithCustomB() throws Exception {
 
-        udf.initialize(new ObjectInspector[] {
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                HiveUtils.getConstStringObjectInspector("-b 0.8")
-        });
+        udf.initialize(
+            new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    HiveUtils.getConstStringObjectInspector("-b 0.8")});
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                VALID_TERM_FREQ,
-                VALID_DOC_LEN,
-                VALID_AVG_DOC_LEN,
-                VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD
-        };
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
+                VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
 
         DoubleWritable expected = WritableUtils.val(0.942443797219);
         DoubleWritable actual = udf.evaluate(args);
@@ -120,13 +108,9 @@ public class OkapiBM25UDFTest {
 
         initializeUDFWithoutOptions();
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                new GenericUDF.DeferredJavaObject(null),
-                VALID_DOC_LEN,
-                VALID_AVG_DOC_LEN,
-                VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD
-        };
+        GenericUDF.DeferredObject[] args =
+                new GenericUDF.DeferredObject[] {new GenericUDF.DeferredJavaObject(null),
+                        VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
 
         udf.evaluate(args);
     }
@@ -135,13 +119,9 @@ public class OkapiBM25UDFTest {
     public void testTermFrequencyIsNegative() throws Exception {
         initializeUDFWithoutOptions();
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                new GenericUDF.DeferredJavaObject(new Integer(-1)),
-                VALID_DOC_LEN,
-                VALID_AVG_DOC_LEN,
-                VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD
-        };
+        GenericUDF.DeferredObject[] args =
+                new GenericUDF.DeferredObject[] {new GenericUDF.DeferredJavaObject(new Integer(-1)),
+                        VALID_DOC_LEN, VALID_AVG_DOC_LEN, VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
 
         udf.evaluate(args);
     }
@@ -150,13 +130,9 @@ public class OkapiBM25UDFTest {
     public void testDocLengthIsLessThanOne() throws Exception {
         initializeUDFWithoutOptions();
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                VALID_TERM_FREQ,
-                new GenericUDF.DeferredJavaObject(new Integer(0)),
-                VALID_AVG_DOC_LEN,
-                VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD
-        };
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
+                new GenericUDF.DeferredJavaObject(new Integer(0)), VALID_AVG_DOC_LEN,
+                VALID_NUM_DOCS, VALID_NUM_DOCS_WITH_WORD};
 
         udf.evaluate(args);
     }
@@ -165,13 +141,9 @@ public class OkapiBM25UDFTest {
     public void testAvgDocLengthIsNegative() throws Exception {
         initializeUDFWithoutOptions();
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                VALID_TERM_FREQ,
-                VALID_DOC_LEN,
-                new GenericUDF.DeferredJavaObject(new Double(-10)),
-                VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD
-        };
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
+                VALID_DOC_LEN, new GenericUDF.DeferredJavaObject(new Double(-10)), VALID_NUM_DOCS,
+                VALID_NUM_DOCS_WITH_WORD};
 
         udf.evaluate(args);
     }
@@ -180,13 +152,9 @@ public class OkapiBM25UDFTest {
     public void testAvgDocLengthIsZero() throws Exception {
         initializeUDFWithoutOptions();
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                VALID_TERM_FREQ,
-                VALID_DOC_LEN,
-                new GenericUDF.DeferredJavaObject(new Double(0.0)),
-                VALID_NUM_DOCS,
-                VALID_NUM_DOCS_WITH_WORD
-        };
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
+                VALID_DOC_LEN, new GenericUDF.DeferredJavaObject(new Double(0.0)), VALID_NUM_DOCS,
+                VALID_NUM_DOCS_WITH_WORD};
 
         udf.evaluate(args);
     }
@@ -195,13 +163,9 @@ public class OkapiBM25UDFTest {
     public void testNumDocsIsLessThanOne() throws Exception {
         initializeUDFWithoutOptions();
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                VALID_TERM_FREQ,
-                VALID_DOC_LEN,
-                VALID_AVG_DOC_LEN,
-                new GenericUDF.DeferredJavaObject(new Integer(0)),
-                VALID_NUM_DOCS_WITH_WORD
-        };
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {VALID_TERM_FREQ,
+                VALID_DOC_LEN, VALID_AVG_DOC_LEN, new GenericUDF.DeferredJavaObject(new Integer(0)),
+                VALID_NUM_DOCS_WITH_WORD};
 
         udf.evaluate(args);
     }
@@ -210,24 +174,19 @@ public class OkapiBM25UDFTest {
     public void testNumDocsWithWordIsLessThanOne() throws Exception {
         initializeUDFWithoutOptions();
 
-        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                VALID_TERM_FREQ,
-                VALID_DOC_LEN,
-                VALID_AVG_DOC_LEN,
-                VALID_NUM_DOCS,
-                new GenericUDF.DeferredJavaObject(new Integer(0))
-        };
+        GenericUDF.DeferredObject[] args =
+                new GenericUDF.DeferredObject[] {VALID_TERM_FREQ, VALID_DOC_LEN, VALID_AVG_DOC_LEN,
+                        VALID_NUM_DOCS, new GenericUDF.DeferredJavaObject(new Integer(0))};
 
         udf.evaluate(args);
     }
 
     private void initializeUDFWithoutOptions() throws Exception {
-        udf.initialize(new ObjectInspector[] {
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                PrimitiveObjectInspectorFactory.javaIntObjectInspector
-        });
+        udf.initialize(
+            new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                    PrimitiveObjectInspectorFactory.javaIntObjectInspector});
     }
 }

--- a/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
@@ -99,7 +99,7 @@ public class OkapiBM25UDFTest {
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
                 PrimitiveObjectInspectorFactory.javaIntObjectInspector,
                 PrimitiveObjectInspectorFactory.javaIntObjectInspector,
-                HiveUtils.getConstStringObjectInspector("-k1 1.5 -b 0.8")
+                HiveUtils.getConstStringObjectInspector("-b 0.8")
         });
 
         GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
@@ -110,7 +110,7 @@ public class OkapiBM25UDFTest {
                 VALID_NUM_DOCS_WITH_WORD
         };
 
-        DoubleWritable expected = WritableUtils.val(0.305108702817);
+        DoubleWritable expected = WritableUtils.val(0.314307452223);
         DoubleWritable actual = udf.evaluate(args);
         assertEquals(expected.get(), actual.get(), EPSILON);
     }

--- a/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 public class OkapiBM25UDFTest {
 
     private static final double EPSILON = 1e-8;
-    private static final GenericUDF.DeferredJavaObject VALID_TERM_FREQ = new GenericUDF.DeferredJavaObject(new Double(0.5));
+    private static final GenericUDF.DeferredJavaObject VALID_TERM_FREQ = new GenericUDF.DeferredJavaObject(new Integer(3));
     private static final GenericUDF.DeferredJavaObject VALID_DOC_LEN = new GenericUDF.DeferredJavaObject(new Integer(9));
     private static final GenericUDF.DeferredJavaObject VALID_AVG_DOC_LEN = new GenericUDF.DeferredJavaObject(new Double(10.35));
     private static final GenericUDF.DeferredJavaObject VALID_NUM_DOCS = new GenericUDF.DeferredJavaObject(new Integer(20));
@@ -60,7 +60,7 @@ public class OkapiBM25UDFTest {
                 VALID_NUM_DOCS_WITH_WORD
         };
 
-        DoubleWritable expected = WritableUtils.val(0.312753184602);
+        DoubleWritable expected = WritableUtils.val(0.727425937348);
         DoubleWritable actual = udf.evaluate(args);
         assertEquals(expected.get(), actual.get(), EPSILON);
     }
@@ -69,7 +69,7 @@ public class OkapiBM25UDFTest {
     public void testEvaluateWithCustomK1() throws Exception {
 
         udf.initialize(new ObjectInspector[] {
-                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
                 PrimitiveObjectInspectorFactory.javaIntObjectInspector,
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
                 PrimitiveObjectInspectorFactory.javaIntObjectInspector,
@@ -85,7 +85,7 @@ public class OkapiBM25UDFTest {
                 VALID_NUM_DOCS_WITH_WORD
         };
 
-        DoubleWritable expected = WritableUtils.val(0.303498158345);
+        DoubleWritable expected = WritableUtils.val(0.775227505584);
         DoubleWritable actual = udf.evaluate(args);
         assertEquals(expected.get(), actual.get(), EPSILON);
     }
@@ -94,7 +94,7 @@ public class OkapiBM25UDFTest {
     public void testEvaluateWithCustomK1AndB() throws Exception {
 
         udf.initialize(new ObjectInspector[] {
-                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
                 PrimitiveObjectInspectorFactory.javaIntObjectInspector,
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
                 PrimitiveObjectInspectorFactory.javaIntObjectInspector,
@@ -110,7 +110,7 @@ public class OkapiBM25UDFTest {
                 VALID_NUM_DOCS_WITH_WORD
         };
 
-        DoubleWritable expected = WritableUtils.val(0.314307452223);
+        DoubleWritable expected = WritableUtils.val(0.728823042222);
         DoubleWritable actual = udf.evaluate(args);
         assertEquals(expected.get(), actual.get(), EPSILON);
     }
@@ -136,7 +136,7 @@ public class OkapiBM25UDFTest {
         initializeUDFWithoutOptions();
 
         GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
-                new GenericUDF.DeferredJavaObject(new Double(-1.0)),
+                new GenericUDF.DeferredJavaObject(new Integer(-1)),
                 VALID_DOC_LEN,
                 VALID_AVG_DOC_LEN,
                 VALID_NUM_DOCS,
@@ -223,7 +223,7 @@ public class OkapiBM25UDFTest {
 
     private void initializeUDFWithoutOptions() throws Exception {
         udf.initialize(new ObjectInspector[] {
-                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
                 PrimitiveObjectInspectorFactory.javaIntObjectInspector,
                 PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
                 PrimitiveObjectInspectorFactory.javaIntObjectInspector,

--- a/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/text/OkapiBM25UDFTest.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package hivemall.ftvec.text;
+
+import static org.junit.Assert.assertEquals;
+
+import hivemall.utils.hadoop.HiveUtils;
+import hivemall.utils.hadoop.WritableUtils;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+public class OkapiBM25UDFTest {
+
+    private static final double EPSILON = 1e-8;
+    OkapiBM25UDF udf = null;
+
+    @Before
+    public void init() throws Exception {
+        udf = new OkapiBM25UDF();
+    }
+
+    @Test
+    public void testEvaluate() throws Exception {
+
+        udf.initialize(new ObjectInspector[] {
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector
+        });
+
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
+                new GenericUDF.DeferredJavaObject(new Double(0.5)),
+                new GenericUDF.DeferredJavaObject(new Integer(9)),
+                new GenericUDF.DeferredJavaObject(new Double(10.35)),
+                new GenericUDF.DeferredJavaObject(new Integer(20)),
+                new GenericUDF.DeferredJavaObject(new Integer(5))
+        };
+
+        DoubleWritable expected = WritableUtils.val(0.312753184602);
+        DoubleWritable actual = udf.evaluate(args);
+        assertEquals(expected.get(), actual.get(), EPSILON);
+    }
+
+    @Test
+    public void testEvaluateWithCustomK1() throws Exception {
+
+        udf.initialize(new ObjectInspector[] {
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                HiveUtils.getConstStringObjectInspector("-k1 1.5")
+        });
+
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
+                new GenericUDF.DeferredJavaObject(new Double(0.5)),
+                new GenericUDF.DeferredJavaObject(new Integer(9)),
+                new GenericUDF.DeferredJavaObject(new Double(10.35)),
+                new GenericUDF.DeferredJavaObject(new Integer(20)),
+                new GenericUDF.DeferredJavaObject(new Integer(5))
+        };
+
+        DoubleWritable expected = WritableUtils.val(0.303498158345);
+        DoubleWritable actual = udf.evaluate(args);
+        assertEquals(expected.get(), actual.get(), EPSILON);
+    }
+
+    @Test
+    public void testEvaluateWithCustomK1AndB() throws Exception {
+
+        udf.initialize(new ObjectInspector[] {
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                HiveUtils.getConstStringObjectInspector("-k1 1.5 -b 0.8")
+        });
+
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
+                new GenericUDF.DeferredJavaObject(new Double(0.5)),
+                new GenericUDF.DeferredJavaObject(new Integer(9)),
+                new GenericUDF.DeferredJavaObject(new Double(10.35)),
+                new GenericUDF.DeferredJavaObject(new Integer(20)),
+                new GenericUDF.DeferredJavaObject(new Integer(5))
+        };
+
+        DoubleWritable expected = WritableUtils.val(0.305108702817);
+        DoubleWritable actual = udf.evaluate(args);
+        assertEquals(expected.get(), actual.get(), EPSILON);
+    }
+
+    @Test(expected = HiveException.class)
+    public void testTermFrequencyIsNull() throws Exception {
+
+        udf.initialize(new ObjectInspector[] {
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector
+        });
+
+        GenericUDF.DeferredObject[] args = new GenericUDF.DeferredObject[] {
+                new GenericUDF.DeferredJavaObject(null),
+                new GenericUDF.DeferredJavaObject(new Integer(9)),
+                new GenericUDF.DeferredJavaObject(new Double(10.35)),
+                new GenericUDF.DeferredJavaObject(new Integer(20)),
+                new GenericUDF.DeferredJavaObject(new Integer(5))
+        };
+
+        udf.evaluate(args);
+    }
+}

--- a/docs/gitbook/SUMMARY.md
+++ b/docs/gitbook/SUMMARY.md
@@ -66,6 +66,7 @@
     * [Feature vectorization](ft_engineering/vectorization.md)
     * [Quantify non-number features](ft_engineering/quantify.md)
 * [TF-IDF Calculation](ft_engineering/tfidf.md)
+* [BM25](ft_engineering/bm25.md)
 
 ## Part IV - Evaluation
 

--- a/docs/gitbook/ft_engineering/bm25.md
+++ b/docs/gitbook/ft_engineering/bm25.md
@@ -1,0 +1,88 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+[Okapi BM25](https://en.wikipedia.org/wiki/Okapi_BM25) is a ranking function for documents for a given query.
+
+It can also be used for a better replacement of [TF-IDF](https://en.wikipedia.org/wiki/Tf%E2%80%93idf) and can be used for term-weight for each document.
+
+<!-- toc -->
+
+# The ranking function
+
+Given a query $$Q$$, containing keywords $$q1,....,q_n$$, the BM25 score of a document $$D$$ is:
+
+$$
+score(Q, D) = \sum_{i=1}^{n}IDF(q_{i}) \cdot \frac{tf(q_{i},D) \cdot (k_{1}+1)}{tf(q_{i},D) + k_{1} \cdot (1 - b + b \cdot \frac{|D|}{avgdl})}
+$$
+
+where $$tf(q_{i}, D)$$ is $$q_{i}$$'s term frequency in the document $$D$$, $$|D|$$ is the length of the document $$D$$ in words, and $$avgdl$$ is the average document length in the text collection from which documents are drawn. $$k_{1}$$ and $$b$$ are free parameters, usually chosen, in absence of an advanced optimization, as $$k_{1} \in [1.2,2.0]$$ and $$b = 0.75$$.
+
+BM25 can also be applied for term weighing, showing how important a word is to a document in a collection or corpus, as follows:
+
+$$
+score(t_{i}, D) = IDF(t_{i}) \cdot \frac{tf(t_{i},D) \cdot (k_{1}+1)}{tf(t_{i},D) + k_{1} \cdot (1 - b + b \cdot \frac{|D|}{avgdl})}
+$$
+
+where $$t_{i}$$ is a term appeared in document $$D$$.
+
+# Data preparation
+
+In similar to [TF-IDF](./tfidf), you need to prepare a relation consists of (docid,word) tuples to compute BM25 score.
+
+```sql
+create external table wikipage (
+  docid int,
+  page string
+)
+ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
+STORED AS TEXTFILE;
+
+cd ~/tmp
+wget https://gist.githubusercontent.com/myui/190b91a3a792ccfceda0/raw/327acd192da4f96da8276dcdff01b19947a4373c/tfidf_test.tsv
+
+LOAD DATA LOCAL INPATH '/home/myui/tmp/tfidf_test.tsv' INTO TABLE wikipage;
+
+create or replace view wikipage_exploded
+as
+select
+  docid, 
+  word
+from
+  wikipage LATERAL VIEW explode(tokenize(page,true)) t as word
+where
+  not is_stopword(word);
+```
+
+# Define views of TF/DF
+
+```
+create or replace view frequency
+as
+select
+  docid,
+  word,
+  count(1) as freq
+from
+  wikipage_exploded
+group by
+  docid,
+  word
+;
+```
+

--- a/docs/gitbook/ft_engineering/bm25.md
+++ b/docs/gitbook/ft_engineering/bm25.md
@@ -115,8 +115,10 @@ group by
 
 # Compute Okapi BM25 score
 
+BM25 (and TF-IDF) score that represents importance of term for each document is useful for feature weight in feature engineering.
+
 ```sql
-create or replace view scores
+create table scores
 as
 select
   tf.docid,
@@ -128,8 +130,8 @@ select
     dl.total_docs,
     df.docs
     -- , '-k1 1.5 -b 0.75'
-  ) as bm25
-  -- ,tfidf(tf.freq, df.docs, dl.total_docs) as tfidf
+  ) as bm25,
+  tfidf(tf.freq, df.docs, dl.total_docs) as tfidf
 from
   term_frequency tf
   JOIN document_frequency df ON (tf.word = df.word)
@@ -137,10 +139,59 @@ from
 ;
 ```
 
-# Show important terms
+## Show important terms
 
 ```sql
-select * from scores
-order by bm25 desc
-limit 100
+select
+  docid, 
+  to_ordered_list(feature(word,bm25), bm25, '-k 10') as bm25_scores,
+  to_ordered_list(feature(word,tfidf),tfidf, '-k 10') as tfidf_scores
+from 
+  scores
+group by
+  docid
+limit 10;
 ```
+
+# Retrive relevant documents for a given search terms
+
+You can retrieve relevant documents for a given search query `wisdom, justice, discussion` as follows:
+
+```sql
+WITH scores as (
+  select
+    tf.docid,
+    tf.word,
+    bm25(
+      tf.freq,
+      dl.dl,
+      dl.avgdl,
+      dl.total_docs,
+      df.docs
+      -- , '-k1 1.5 -b 0.75'
+    ) as bm25,
+    tfidf(tf.freq, df.docs, dl.total_docs) as tfidf
+  from
+    term_frequency tf
+    JOIN document_frequency df ON (tf.word = df.word)
+    JOIN doc_len dl ON (tf.docid = dl.docid)
+  where
+    tf.word in ('wisdom', 'justice', 'discussion')
+)
+select
+  docid,
+  sum(bm25) as score 
+from
+  scores 
+group by
+  docid
+order by
+  score DESC 
+LIMIT 10
+;
+```
+
+| docid | score |
+|:-:|:-:|
+| 1 | 0.14190456024682774 |
+| 2 | 0.02197354085722251 |

--- a/docs/gitbook/ft_engineering/bm25.md
+++ b/docs/gitbook/ft_engineering/bm25.md
@@ -69,20 +69,78 @@ where
   not is_stopword(word);
 ```
 
-# Define views of TF/DF
+# Define views of term/doc frequency
 
-```
-create or replace view frequency
+```sql
+create or replace view term_frequency 
 as
 select
-  docid,
-  word,
-  count(1) as freq
+  t1.docid, 
+  t2.word,
+  t2.freq
+from (
+  select
+    docid,
+    tf(word) as word2freq
+  from
+    wikipage_exploded
+  group by
+    docid
+) t1 
+LATERAL VIEW explode(word2freq) t2 as word, freq;
+
+create or replace view document_frequency
+as
+select
+  word, 
+  count(distinct docid) docs
 from
   wikipage_exploded
 group by
-  docid,
-  word
+  word;
+
+create or replace view doc_len
+as
+select 
+  docid, 
+  count(1) as dl,
+  avg(count(1)) over () as avgdl,
+  count(distinct docid) over () as total_docs
+from
+  wikipage_exploded
+group by
+  docid
 ;
 ```
 
+# Compute Okapi BM25 score
+
+```sql
+create or replace view scores
+as
+select
+  tf.docid,
+  tf.word,
+  bm25(
+    tf.freq,
+    dl.dl,
+    dl.avgdl,
+    dl.total_docs,
+    df.docs
+    -- , '-k1 1.5 -b 0.75'
+  ) as bm25
+  -- ,tfidf(tf.freq, df.docs, dl.total_docs) as tfidf
+from
+  term_frequency tf
+  JOIN document_frequency df ON (tf.word = df.word)
+  JOIN doc_len dl ON (tf.docid = dl.docid)
+;
+```
+
+# Show important terms
+
+```sql
+select * from scores
+order by bm25 desc
+limit 100
+```

--- a/docs/gitbook/misc/funcs.md
+++ b/docs/gitbook/misc/funcs.md
@@ -532,7 +532,7 @@ This page describes a list of Hivemall functions. See also a [list of generic Hi
   WITH dual AS (SELECT 1) SELECT lr_datagen('-n_examples 1k -n_features 10') FROM dual;
   ```
 
-- `okapi_bm25(double tf_word, int dl, double avgdl, int N, int n [, const string options])` - Return an Okapi BM25 score in float
+- `okapi_bm25(int f, int dl, double avgdl, int N, int n [, const string options])` - Return an Okapi BM25 score in double
 
 - `tf(string text)` - Return a term frequency in &lt;string, float&gt;
 

--- a/docs/gitbook/misc/funcs.md
+++ b/docs/gitbook/misc/funcs.md
@@ -532,7 +532,7 @@ This page describes a list of Hivemall functions. See also a [list of generic Hi
   WITH dual AS (SELECT 1) SELECT lr_datagen('-n_examples 1k -n_features 10') FROM dual;
   ```
 
-- `okapi_bm25(int f, int dl, double avgdl, int N, int n [, const string options])` - Return an Okapi BM25 score in double
+- `okapi_bm25(int termFrequency, int docLength, double avgDocLength, int numDocs, int numDocsWithTerm [, const string options])` - Return an Okapi BM25 score in double
 
 - `tf(string text)` - Return a term frequency in &lt;string, float&gt;
 

--- a/docs/gitbook/misc/funcs.md
+++ b/docs/gitbook/misc/funcs.md
@@ -532,7 +532,7 @@ This page describes a list of Hivemall functions. See also a [list of generic Hi
   WITH dual AS (SELECT 1) SELECT lr_datagen('-n_examples 1k -n_features 10') FROM dual;
   ```
 
-- `okapi_bm25(int termFrequency, int docLength, double avgDocLength, int numDocs, int numDocsWithTerm [, const string options])` - Return an Okapi BM25 score in double
+- `bm25(int termFrequency, int docLength, double avgDocLength, int numDocs, int numDocsWithTerm [, const string options])` - Return an Okapi BM25 score in double
 
 - `tf(string text)` - Return a term frequency in &lt;string, float&gt;
 

--- a/docs/gitbook/misc/funcs.md
+++ b/docs/gitbook/misc/funcs.md
@@ -532,5 +532,7 @@ This page describes a list of Hivemall functions. See also a [list of generic Hi
   WITH dual AS (SELECT 1) SELECT lr_datagen('-n_examples 1k -n_features 10') FROM dual;
   ```
 
+- `okapi_bm25(double tf_word, int dl, double avgdl, int N, int n [, const string options])` - Return an Okapi BM25 score in float
+
 - `tf(string text)` - Return a term frequency in &lt;string, float&gt;
 

--- a/resources/ddl/define-all-as-permanent.hive
+++ b/resources/ddl/define-all-as-permanent.hive
@@ -875,3 +875,6 @@ CREATE FUNCTION xgboost_predict AS 'hivemall.xgboost.tools.XGBoostPredictUDTF' U
 
 DROP FUNCTION xgboost_multiclass_predict;
 CREATE FUNCTION xgboost_multiclass_predict AS 'hivemall.xgboost.tools.XGBoostMulticlassPredictUDTF' USING JAR '${hivemall_jar}';
+
+DROP FUNCTION IF EXISTS okapi_bm25;
+CREATE FUNCTION okapi_bm25 as 'hivemall.ftvec.text.OkapiBM25UDF' USING JAR '${hivemall_jar}';

--- a/resources/ddl/define-all-as-permanent.hive
+++ b/resources/ddl/define-all-as-permanent.hive
@@ -343,6 +343,9 @@ CREATE FUNCTION populate_not_in as 'hivemall.ftvec.ranking.PopulateNotInUDTF' US
 DROP FUNCTION IF EXISTS tf;
 CREATE FUNCTION tf as 'hivemall.ftvec.text.TermFrequencyUDAF' USING JAR '${hivemall_jar}';
 
+DROP FUNCTION IF EXISTS bm25;
+CREATE FUNCTION bm25 as 'hivemall.ftvec.text.OkapiBM25UDF' USING JAR '${hivemall_jar}';
+
 --------------------------
 -- Regression functions --
 --------------------------
@@ -875,6 +878,3 @@ CREATE FUNCTION xgboost_predict AS 'hivemall.xgboost.tools.XGBoostPredictUDTF' U
 
 DROP FUNCTION xgboost_multiclass_predict;
 CREATE FUNCTION xgboost_multiclass_predict AS 'hivemall.xgboost.tools.XGBoostMulticlassPredictUDTF' USING JAR '${hivemall_jar}';
-
-DROP FUNCTION IF EXISTS okapi_bm25;
-CREATE FUNCTION okapi_bm25 as 'hivemall.ftvec.text.OkapiBM25UDF' USING JAR '${hivemall_jar}';

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -339,6 +339,9 @@ create temporary function populate_not_in as 'hivemall.ftvec.ranking.PopulateNot
 drop temporary function if exists tf;
 create temporary function tf as 'hivemall.ftvec.text.TermFrequencyUDAF';
 
+drop temporary function if exists bm25;
+create temporary function bm25 as 'hivemall.ftvec.text.OkapiBM25UDF';
+
 --------------------------
 -- Regression functions --
 --------------------------
@@ -882,5 +885,3 @@ log(10, n_docs / max2(1,df_t)) + 1.0;
 create temporary macro tfidf(tf FLOAT, df_t DOUBLE, n_docs DOUBLE)
 tf * (log(10, n_docs / max2(1,df_t)) + 1.0);
 
-drop temporary function if exists okapi_bm25;
-create temporary function okapi_bm25 as 'hivemall.ftvec.text.OkapiBM25UDF';

--- a/resources/ddl/define-all.hive
+++ b/resources/ddl/define-all.hive
@@ -881,3 +881,6 @@ log(10, n_docs / max2(1,df_t)) + 1.0;
 
 create temporary macro tfidf(tf FLOAT, df_t DOUBLE, n_docs DOUBLE)
 tf * (log(10, n_docs / max2(1,df_t)) + 1.0);
+
+drop temporary function if exists okapi_bm25;
+create temporary function okapi_bm25 as 'hivemall.ftvec.text.OkapiBM25UDF';

--- a/resources/ddl/define-all.spark
+++ b/resources/ddl/define-all.spark
@@ -834,3 +834,6 @@ sqlContext.sql("CREATE TEMPORARY FUNCTION bloom_or AS 'hivemall.sketch.bloom.Blo
 
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS bloom_contains_any")
 sqlContext.sql("CREATE TEMPORARY FUNCTION bloom_contains_any AS 'hivemall.sketch.bloom.BloomContainsAnyUDF'")
+
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS okapi_bm25")
+sqlContext.sql("CREATE TEMPORARY FUNCTION okapi_bm25 AS 'hivemall.ftvec.text.OkapiBM25UDF'")

--- a/resources/ddl/define-all.spark
+++ b/resources/ddl/define-all.spark
@@ -342,6 +342,9 @@ sqlContext.sql("CREATE TEMPORARY FUNCTION populate_not_in AS 'hivemall.ftvec.ran
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS tf")
 sqlContext.sql("CREATE TEMPORARY FUNCTION tf AS 'hivemall.ftvec.text.TermFrequencyUDAF'")
 
+sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS bm25")
+sqlContext.sql("CREATE TEMPORARY FUNCTION bm25 AS 'hivemall.ftvec.text.OkapiBM25UDF'")
+
 /**
  * Regression functions
  */
@@ -835,5 +838,3 @@ sqlContext.sql("CREATE TEMPORARY FUNCTION bloom_or AS 'hivemall.sketch.bloom.Blo
 sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS bloom_contains_any")
 sqlContext.sql("CREATE TEMPORARY FUNCTION bloom_contains_any AS 'hivemall.sketch.bloom.BloomContainsAnyUDF'")
 
-sqlContext.sql("DROP TEMPORARY FUNCTION IF EXISTS okapi_bm25")
-sqlContext.sql("CREATE TEMPORARY FUNCTION okapi_bm25 AS 'hivemall.ftvec.text.OkapiBM25UDF'")


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adding scoring function Okapi BM25 as a UDF

## What type of PR is it?

Feature

## What is the Jira issue?

https://issues.apache.org/jira/projects/HIVEMALL/issues/HIVEMALL-196

## How was this patch tested?

1. Unit testing
2. Manual testing on Hive

## How to use this feature?
This new `okapi_bm25` function requires 5 mandatory arguments and 2 optional hyperparameters:

1. raw frequency count of a term in a given document
2. length of the given document
3. average length of a document in the corpus
4. number of documents in the corpus
5. number of documents containing the term, i.e. document frequency
6. (*optional*) k1 - a smoothing hyperparameter
7. (*optional*) b - a smoothing hyperparameter

### Step 1: Count frequency of terms
```sql
create or replace view frequency
as
select
  docid,
  word,
  count(*) as freq
from
  test_corpus_exploded
group by
  docid,
  word
;
```

### Step 2: Calculate document lengths
```sql
create or replace view doc_len
as
select 
  docid, count(1) as cnt 
from
  test_corpus_exploded
group by
  docid
;
```

### Step 3: Calculate document frequency
```sql
create or replace view document_frequency
as
select
  word, 
  count(distinct docid) docs
from
  test_corpus_exploded
group by
  word
;
```

### Step 4: Set number of documents
```sql
set hivevar:n_docs=3;
```

### Step 5: Use `okapi_bm25`
```sql
create or replace view bm25 
	as
with tmp as (
	select avg(cnt) as avgdl from doc_len
)
select
  f.docid,
  f.word,
  okapi_bm25(
    CAST(f.freq AS INT),
    dl.cnt,
    CAST(tmp.avgdl AS DOUBLE),
    ${n_docs},
    df.docs,
    '-k1 1.5 -b 0.75'
  ) as score
from frequency     f
JOIN document_frequency df ON (f.word = df.word)
JOIN doc_len            dl ON (f.docid = dl.docid)
CROSS JOIN tmp
ORDER BY
score desc;
```

## Checklist

(Please remove this section if not needed; check `x` for YES, blank for NO)

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
