### PR TITLE
[HIVEMALL-221] Add cache to reduce Maven build time on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 cache:
   timeout: 1500
   directories:
-  - $HOME/.m2
+  - $HOME/.m2/repository
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 
 cache:
-  timeout: 1000
+  timeout: 1500
   directories:
   - $HOME/.m2
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ notifications:
   email: false
 
 script:
-  - ./bin/run_travis_tests.sh
+  - travis_wait 10 ./bin/run_travis_tests.sh
 
 after_success:
   - mvn clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 
+cache:
+  directories:
+  - $HOME/.m2
+
 env:
   global:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ notifications:
   email: false
 
 script:
-  - travis_wait 10 ./bin/run_travis_tests.sh
+  - ./bin/run_travis_tests.sh
 
 after_success:
   - mvn clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 
 cache:
+  timeout: 1000
   directories:
   - $HOME/.m2
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR will speed up the build time on Travis CI. Travis CI will timeout when the build time over 50 minutes (See [documentation](https://docs.travis-ci.com/user/customizing-the-build#build-timeouts)).

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-221
