### PR TITLE
[HIVEMALL-223] Add -kv_map and -vk_map option to to_ordered_list UDAF

### DIFF
--- a/core/src/main/java/hivemall/tools/list/UDAFToOrderedList.java
+++ b/core/src/main/java/hivemall/tools/list/UDAFToOrderedList.java
@@ -88,7 +88,9 @@ import org.apache.hadoop.io.IntWritable;
                 + "    to_ordered_list(value, key, '-k -2 -reverse'), -- [apple, candy] (reverse tail-k = top-k)\n"
                 + "    to_ordered_list(value, '-k 2'),                -- [egg, donut] (alphabetically)\n"
                 + "    to_ordered_list(key, '-k -2 -reverse'),        -- [5, 4] (top-2 keys)\n"
-                + "    to_ordered_list(key)                           -- [2, 3, 3, 4, 5] (natural ordered keys)\n"
+                + "    to_ordered_list(key),                          -- [2, 3, 3, 4, 5] (natural ordered keys)\n"
+                + "    to_ordered_list(value, key, '-k -2 -kv_map'),  -- \n"
+                + "    to_ordered_list(value, key, '-k -2 -vk_map')   -- \n"
                 + "FROM\n" + "    t")
 //@formatter:on
 public final class UDAFToOrderedList extends AbstractGenericUDAFResolver {
@@ -438,7 +440,7 @@ public final class UDAFToOrderedList extends AbstractGenericUDAFResolver {
 
         static class QueueAggregationBuffer extends AbstractAggregationBuffer {
 
-            private AbstractQueueHandler queueHandler;
+            private transient AbstractQueueHandler queueHandler;
 
             @Nonnegative
             private int size;

--- a/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
+++ b/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
 import org.apache.hadoop.hive.serde2.objectinspector.StandardConstantListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
@@ -1227,4 +1228,24 @@ public final class HiveUtils {
             TypeInfoFactory.stringTypeInfo, new Text(str));
     }
 
+    @Nullable
+    public static StructField getStructFieldRef(@Nonnull String fieldName,
+            @Nonnull final List<? extends StructField> fields) {
+        fieldName = fieldName.toLowerCase();
+        for (StructField f : fields) {
+            if (f.getFieldName().equals(fieldName)) {
+                return f;
+            }
+        }
+        // For backward compatibility: fieldNames can also be integer Strings.
+        try {
+            final int i = Integer.parseInt(fieldName);
+            if (i >= 0 && i < fields.size()) {
+                return fields.get(i);
+            }
+        } catch (NumberFormatException e) {
+            // ignore
+        }
+        return null;
+    }
 }

--- a/core/src/test/java/hivemall/tools/list/UDAFToOrderedListTest.java
+++ b/core/src/test/java/hivemall/tools/list/UDAFToOrderedListTest.java
@@ -21,8 +21,11 @@ package hivemall.tools.list;
 import hivemall.tools.list.UDAFToOrderedList.UDAFToOrderedListEvaluator;
 import hivemall.tools.list.UDAFToOrderedList.UDAFToOrderedListEvaluator.QueueAggregationBuffer;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
@@ -56,7 +59,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(3, res.size());
         Assert.assertEquals("apple", res.get(0));
@@ -81,7 +85,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(3, res.size());
         Assert.assertEquals("candy", res.get(0));
@@ -105,7 +110,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(2, res.size());
         Assert.assertEquals("candy", res.get(0));
@@ -130,7 +136,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(2, res.size());
         Assert.assertEquals("apple", res.get(0));
@@ -153,7 +160,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(2, res.size());
         Assert.assertEquals("apple", res.get(0));
@@ -178,7 +186,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(2, res.size());
         Assert.assertEquals("candy", res.get(0));
@@ -201,7 +210,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i], keys[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(3, res.size());
         Assert.assertEquals("apple", res.get(0));
@@ -231,6 +241,7 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i], keys[i]});
         }
 
+        @SuppressWarnings("unchecked")
         List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(3, res.size());
@@ -260,7 +271,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i], keys[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(2, res.size());
         Assert.assertEquals("candy", res.get(0));
@@ -287,7 +299,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i], keys[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(2, res.size());
         Assert.assertEquals("apple", res.get(0));
@@ -312,7 +325,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i], keys[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(2, res.size());
         Assert.assertEquals("apple", res.get(0));
@@ -339,7 +353,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i], keys[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(2, res.size());
         Assert.assertEquals("candy", res.get(0));
@@ -360,7 +375,8 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertNull(res);
     }
@@ -379,12 +395,179 @@ public class UDAFToOrderedListTest {
             evaluator.iterate(agg, new Object[] {values[i]});
         }
 
-        List<Object> res = evaluator.terminate(agg);
+        @SuppressWarnings("unchecked")
+        List<Object> res = (List<Object>) evaluator.terminate(agg);
 
         Assert.assertEquals(3, res.size());
         Assert.assertEquals("apple", res.get(0));
         Assert.assertEquals("banana", res.get(1));
         Assert.assertEquals("candy", res.get(2));
+    }
+
+    @Test
+    public void testKVMapOption() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                            "-k 2 -kv_map")};
+
+        final String[] values = new String[] {"banana", "apple", "candy"};
+        final double[] keys = new double[] {0.7, 0.5, 0.8};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
+        evaluator.reset(agg);
+
+        for (int i = 0; i < values.length; i++) {
+            evaluator.iterate(agg, new Object[] {values[i], keys[i]});
+        }
+
+        Object result = evaluator.terminate(agg);
+
+        Assert.assertEquals(HashMap.class, result.getClass());
+        Map<?, ?> map = (Map<?, ?>) result;
+        Assert.assertEquals(2, map.size());
+
+        Assert.assertEquals("candy", map.get(0.8d));
+        Assert.assertEquals("banana", map.get(0.7d));
+    }
+
+    @Test
+    public void testVKMapOption() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                            "-k 2 -vk_map")};
+
+        final String[] values = new String[] {"banana", "apple", "candy"};
+        final double[] keys = new double[] {0.7, 0.5, 0.8};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
+        evaluator.reset(agg);
+
+        for (int i = 0; i < values.length; i++) {
+            evaluator.iterate(agg, new Object[] {values[i], keys[i]});
+        }
+
+        Object result = evaluator.terminate(agg);
+
+        Assert.assertEquals(HashMap.class, result.getClass());
+        Map<?, ?> map = (Map<?, ?>) result;
+        Assert.assertEquals(2, map.size());
+
+        Assert.assertEquals(0.8d, map.get("candy"));
+        Assert.assertEquals(0.7d, map.get("banana"));
+    }
+
+    @Test
+    public void testVKMapOptionBananaOverlapNaturalOrder() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                            "-k 2 -vk_map")};
+
+        final String[] values = new String[] {"banana", "banana", "candy"};
+        final double[] keys = new double[] {0.7, 0.5, 0.8};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
+        evaluator.reset(agg);
+
+        for (int i = 0; i < values.length; i++) {
+            evaluator.iterate(agg, new Object[] {values[i], keys[i]});
+        }
+
+        Object result = evaluator.terminate(agg);
+
+        Assert.assertEquals(HashMap.class, result.getClass());
+        Map<?, ?> map = (Map<?, ?>) result;
+        Assert.assertEquals(1, map.size());
+
+        Assert.assertEquals(0.7d, map.get("banana"));
+    }
+
+    @Test
+    public void testVKMapOptionReverseNaturalOrder() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                            "-k -2 -vk_map")};
+
+        final String[] values = new String[] {"banana", "apple", "banana"};
+        final double[] keys = new double[] {0.7, 0.7, 0.8};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
+        evaluator.reset(agg);
+
+        for (int i = 0; i < values.length; i++) {
+            evaluator.iterate(agg, new Object[] {values[i], keys[i]});
+        }
+
+        Object result = evaluator.terminate(agg);
+
+        Assert.assertEquals(HashMap.class, result.getClass());
+        Map<?, ?> map = (Map<?, ?>) result;
+        Assert.assertEquals(2, map.size());
+
+        Assert.assertEquals(0.8d, map.get("banana"));
+        Assert.assertEquals(0.7d, map.get("apple"));
+    }
+
+    @Test
+    public void testVKMapOptionBananaOverlapReverseNaturalOrder() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                            "-k -2 -vk_map")};
+
+        final String[] values = new String[] {"banana", "banana", "candy"};
+        final double[] keys = new double[] {0.9, 0.8, 0.7};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
+        evaluator.reset(agg);
+
+        for (int i = 0; i < values.length; i++) {
+            evaluator.iterate(agg, new Object[] {values[i], keys[i]});
+        }
+
+        Object result = evaluator.terminate(agg);
+
+        Assert.assertEquals(HashMap.class, result.getClass());
+        Map<?, ?> map = (Map<?, ?>) result;
+        Assert.assertEquals(1, map.size());
+
+        Assert.assertEquals(0.8d, map.get("banana"));
+    }
+
+    @Test(expected = UDFArgumentException.class)
+    public void testKVandVKFail() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                            "-k 2 -kv_map -vk_map")};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
+    }
+
+    @Test(expected = UDFArgumentException.class)
+    public void testKVMapReturnWithoutValue() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                            "-k 2 -kv_map ")};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
     }
 
 }

--- a/core/src/test/java/hivemall/tools/list/UDAFToOrderedListTest.java
+++ b/core/src/test/java/hivemall/tools/list/UDAFToOrderedListTest.java
@@ -680,6 +680,64 @@ public class UDAFToOrderedListTest {
         Assert.assertEquals(0.8d, map.get("banana"));
     }
 
+    @Test
+    public void testVKMapTop2() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                            "-k 2 -vk_map")};
+
+        final int[] keys = new int[] {5, 3, 4, 2, 3};
+        final String[] values = new String[] {"apple", "banana", "candy", "donut", "egg"};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
+        evaluator.reset(agg);
+
+        for (int i = 0; i < values.length; i++) {
+            evaluator.iterate(agg, new Object[] {values[i], keys[i]});
+        }
+
+        Object result = evaluator.terminate(agg);
+
+        Assert.assertEquals(HashMap.class, result.getClass());
+        Map<?, ?> map = (Map<?, ?>) result;
+        Assert.assertEquals(2, map.size());
+
+        Assert.assertEquals(5, map.get("apple"));
+        Assert.assertEquals(4, map.get("candy"));
+    }
+
+    @Test
+    public void testKVMapTop2() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaIntObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                            "-k 2 -kv_map")};
+
+        final int[] keys = new int[] {5, 3, 4, 2, 3};
+        final String[] values = new String[] {"apple", "banana", "candy", "donut", "egg"};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
+        evaluator.reset(agg);
+
+        for (int i = 0; i < values.length; i++) {
+            evaluator.iterate(agg, new Object[] {values[i], keys[i]});
+        }
+
+        Object result = evaluator.terminate(agg);
+
+        Assert.assertEquals(HashMap.class, result.getClass());
+        Map<?, ?> map = (Map<?, ?>) result;
+        Assert.assertEquals(2, map.size());
+
+        Assert.assertEquals("apple", map.get(5));
+        Assert.assertEquals("candy", map.get(4));
+    }
+
     @Test(expected = UDFArgumentException.class)
     public void testKVandVKFail() throws Exception {
         ObjectInspector[] inputOIs =

--- a/core/src/test/java/hivemall/utils/collections/BoundedPriorityQueueTest.java
+++ b/core/src/test/java/hivemall/utils/collections/BoundedPriorityQueueTest.java
@@ -111,4 +111,37 @@ public class BoundedPriorityQueueTest {
         Assert.assertNull(queue.poll());
     }
 
+    @Test
+    public void testReverseOrderForTailK() {
+        // Note that queue holds tail-k elements for reverseOrder
+        BoundedPriorityQueue<Integer> queue =
+                new BoundedPriorityQueue<Integer>(2, Collections.<Integer>reverseOrder());
+        queue.offer(3);
+        queue.offer(1);
+        queue.offer(2);
+        queue.offer(4);
+        queue.offer(-1);
+
+        Assert.assertEquals(2, queue.size());
+        // but order by reverse order
+        Assert.assertEquals(1, queue.poll().intValue());
+        Assert.assertEquals(-1, queue.poll().intValue());
+    }
+
+    @Test
+    public void testNaturalOrderForTopK() {
+        // Note that queue holds top-k elements for Natural
+        BoundedPriorityQueue<Integer> queue =
+                new BoundedPriorityQueue<Integer>(2, NaturalComparator.<Integer>getInstance());
+        queue.offer(3);
+        queue.offer(1);
+        queue.offer(2);
+        queue.offer(4);
+        queue.offer(-1);
+
+        Assert.assertEquals(2, queue.size());
+        // but order by natural order
+        Assert.assertEquals(3, queue.poll().intValue());
+        Assert.assertEquals(4, queue.poll().intValue());
+    }
 }


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `-kv_map` and `-vk_map` option to `to_ordered_list` UDAF.

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-223

## How was this patch tested?

unit tests and manual tests on EMR

## How to use this feature?

Will be described in 
http://hivemall.incubator.apache.org/userguide/misc/generic_funcs.html#array

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
