### PR TITLE
[HIVEMALL-232][DOC] Fix typo in the Top-K document

### DIFF
--- a/docs/gitbook/misc/topk.md
+++ b/docs/gitbook/misc/topk.md
@@ -93,7 +93,7 @@ FROM (
 
 > #### Note
 >
-> `CLUSTER BY x` is a synonym of `DISTRIBUTE BY x CLASS SORT BY x` and required when using `each_top_k`.
+> `CLUSTER BY x` is a synonym of `DISTRIBUTE BY x SORT BY x` and required when using `each_top_k`.
 
 The function signature of `each_top_k` is `each_top_k(int k, ANY group, double value, arg1, arg2, ..., argN)` and it returns a relation `(int rank, double value, arg1, arg2, .., argN)`.
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

`DISTRIBUTE BY x CLASS SORT BY x` in the Top-K document looks like a typo, so fixing it.

## What type of PR is it?

Documentation

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-232

## How was this patch tested?

I think no test is needed since it's just a minor documentation fix.