### PR TITLE
[HIVEMALL-234] Define `EtaEstimator` default values as constants

### DIFF
--- a/core/src/main/java/hivemall/fm/FactorizationMachineUDTF.java
+++ b/core/src/main/java/hivemall/fm/FactorizationMachineUDTF.java
@@ -152,11 +152,12 @@ public class FactorizationMachineUDTF extends UDTFWithOptions {
         opts.addOption("min", "min_target", true, "The minimum value of target variable");
         opts.addOption("max", "max_target", true, "The maximum value of target variable");
         // learning rates
-        opts.addOption("eta", true, "The initial learning rate");
-        opts.addOption("eta0", true, "The initial learning rate [default " + DEFAULT_ETA0 + "]");
+        opts.addOption("eta", true,
+            "The initial learning rate [default: " + EtaEstimator.DEFAULT_ETA + "]");
+        opts.addOption("eta0", true, "The initial learning rate [default: " + DEFAULT_ETA0 + "]");
         opts.addOption("t", "total_steps", true, "The total number of training examples");
-        opts.addOption("power_t", true,
-            "The exponent for inverse scaling learning rate [default 0.1]");
+        opts.addOption("power_t", true, "The exponent for inverse scaling learning rate [default: "
+                + EtaEstimator.DEFAULT_POWER_T + "]");
         // conversion check
         opts.addOption("disable_cv", "disable_cvtest", false,
             "Whether to disable convergence check [default: OFF]");

--- a/core/src/main/java/hivemall/mf/BPRMatrixFactorizationUDTF.java
+++ b/core/src/main/java/hivemall/mf/BPRMatrixFactorizationUDTF.java
@@ -165,11 +165,13 @@ public final class BPRMatrixFactorizationUDTF extends UDTFWithOptions implements
             "The regularization factor for bias clause [default: 0.01]");
         opts.addOption("disable_bias", "no_bias", false, "Turn off bias clause");
         // learning rates
-        opts.addOption("eta", true, "The initial learning rate [default: 0.001]");
-        opts.addOption("eta0", true, "The initial learning rate [default 0.3]");
+        opts.addOption("eta", true,
+            "The initial learning rate [default: " + EtaEstimator.DEFAULT_ETA + "]");
+        opts.addOption("eta0", true,
+            "The initial learning rate [default: " + EtaEstimator.DEFAULT_ETA0 + "]");
         opts.addOption("t", "total_steps", true, "The total number of training examples");
-        opts.addOption("power_t", true,
-            "The exponent for inverse scaling learning rate [default 0.1]");
+        opts.addOption("power_t", true, "The exponent for inverse scaling learning rate [default: "
+                + EtaEstimator.DEFAULT_POWER_T + "]");
         opts.addOption("boldDriver", "bold_driver", false,
             "Whether to use Bold Driver for learning rate [default: false]");
         // conversion check

--- a/core/src/main/java/hivemall/mf/MatrixFactorizationSGDUDTF.java
+++ b/core/src/main/java/hivemall/mf/MatrixFactorizationSGDUDTF.java
@@ -40,11 +40,13 @@ public final class MatrixFactorizationSGDUDTF extends OnlineMatrixFactorizationU
     @Override
     protected Options getOptions() {
         Options opts = super.getOptions();
-        opts.addOption("eta", true, "The initial learning rate [default: 0.001]");
-        opts.addOption("eta0", true, "The initial learning rate [default 0.2]");
+        opts.addOption("eta", true,
+            "The initial learning rate [default: " + EtaEstimator.DEFAULT_ETA + "]");
+        opts.addOption("eta0", true,
+            "The initial learning rate [default: " + EtaEstimator.DEFAULT_ETA0 + "]");
         opts.addOption("t", "total_steps", true, "The total number of training examples");
-        opts.addOption("power_t", true,
-            "The exponent for inverse scaling learning rate [default 0.1]");
+        opts.addOption("power_t", true, "The exponent for inverse scaling learning rate [default: "
+                + EtaEstimator.DEFAULT_POWER_T + "]");
         return opts;
     }
 

--- a/core/src/main/java/hivemall/optimizer/EtaEstimator.java
+++ b/core/src/main/java/hivemall/optimizer/EtaEstimator.java
@@ -33,6 +33,10 @@ import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 
 public abstract class EtaEstimator {
 
+    public static final float DEFAULT_ETA0 = 0.1f;
+    public static final float DEFAULT_ETA = 0.3f;
+    public static final double DEFAULT_POWER_T = 0.1d;
+
     protected final float eta0;
 
     public EtaEstimator(float eta0) {
@@ -150,18 +154,18 @@ public abstract class EtaEstimator {
 
     @Nonnull
     public static EtaEstimator get(@Nullable CommandLine cl) throws UDFArgumentException {
-        return get(cl, 0.1f);
+        return get(cl, DEFAULT_ETA0);
     }
 
     @Nonnull
     public static EtaEstimator get(@Nullable CommandLine cl, float defaultEta0)
             throws UDFArgumentException {
         if (cl == null) {
-            return new InvscalingEtaEstimator(defaultEta0, 0.1d);
+            return new InvscalingEtaEstimator(defaultEta0, DEFAULT_POWER_T);
         }
 
         if (cl.hasOption("boldDriver")) {
-            float eta = Primitives.parseFloat(cl.getOptionValue("eta"), 0.3f);
+            float eta = Primitives.parseFloat(cl.getOptionValue("eta"), DEFAULT_ETA);
             return new AdjustingEtaEstimator(eta);
         }
 
@@ -177,15 +181,15 @@ public abstract class EtaEstimator {
             return new SimpleEtaEstimator(eta0, t);
         }
 
-        double power_t = Primitives.parseDouble(cl.getOptionValue("power_t"), 0.1d);
+        double power_t = Primitives.parseDouble(cl.getOptionValue("power_t"), DEFAULT_POWER_T);
         return new InvscalingEtaEstimator(eta0, power_t);
     }
 
     @Nonnull
     public static EtaEstimator get(@Nonnull final Map<String, String> options)
             throws IllegalArgumentException {
-        final float eta0 = Primitives.parseFloat(options.get("eta0"), 0.1f);
-        final double power_t = Primitives.parseDouble(options.get("power_t"), 0.1d);
+        final float eta0 = Primitives.parseFloat(options.get("eta0"), DEFAULT_ETA0);
+        final double power_t = Primitives.parseDouble(options.get("power_t"), DEFAULT_POWER_T);
 
         final String etaScheme = options.get("eta");
         if (etaScheme == null) {

--- a/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
+++ b/core/src/main/java/hivemall/optimizer/OptimizerOptions.java
@@ -56,10 +56,11 @@ public final class OptimizerOptions {
         opts.addOption("lambda", true, "Regularization term [default 0.0001]");
         // learning rates
         opts.addOption("eta", true, "Learning rate scheme [default: inverse/inv, fixed, simple]");
-        opts.addOption("eta0", true, "The initial learning rate [default 0.1]");
+        opts.addOption("eta0", true,
+            "The initial learning rate [default: " + EtaEstimator.DEFAULT_ETA0 + "]");
         opts.addOption("t", "total_steps", true, "a total of n_samples * epochs time steps");
-        opts.addOption("power_t", true,
-            "The exponent for inverse scaling learning rate [default 0.1]");
+        opts.addOption("power_t", true, "The exponent for inverse scaling learning rate [default: "
+                + EtaEstimator.DEFAULT_POWER_T + "]");
         opts.addOption("alpha", true,
             "Coefficient of learning rate [default: 1.0 (adam/RMSPropGraves), 0.02 (AdamHD/Nesterov)]");
         // ADAM hyperparameters

--- a/core/src/main/java/hivemall/regression/LogressUDTF.java
+++ b/core/src/main/java/hivemall/regression/LogressUDTF.java
@@ -55,11 +55,11 @@ public final class LogressUDTF extends RegressionBaseUDTF {
     @Override
     protected Options getOptions() {
         Options opts = super.getOptions();
-        opts.addOption("t", "total_steps", true,
-            "a total of n_samples * epochs time steps [default: 10000]");
-        opts.addOption("power_t", true,
-            "The exponent for inverse scaling learning rate [default 0.1]");
-        opts.addOption("eta0", true, "The initial learning rate [default 0.1]");
+        opts.addOption("t", "total_steps", true, "a total of n_samples * epochs time steps");
+        opts.addOption("power_t", true, "The exponent for inverse scaling learning rate [default: "
+                + EtaEstimator.DEFAULT_POWER_T + "]");
+        opts.addOption("eta0", true,
+            "The initial learning rate [default: " + EtaEstimator.DEFAULT_ETA0 + "]");
         return opts;
     }
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix mismatched default values declared in `getOptions()` and `EtaEstimator`.

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-234

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?