### PR TITLE
[HIVEMALL-246] Add feature name validation in feature UDF

### DIFF
--- a/core/src/main/java/hivemall/ftvec/FeatureUDF.java
+++ b/core/src/main/java/hivemall/ftvec/FeatureUDF.java
@@ -101,6 +101,9 @@ public final class FeatureUDF extends GenericUDF {
         // arg0|arg1 is Primitive Java object or Writable
         // Then, toString() works fine
         String featureStr = arg0.toString();
+        if (featureStr.indexOf(':') >= 0) {
+            throw new HiveException("feature name SHOULD NOT contain colon: " + featureStr);
+        }
         String valueStr = arg1.toString();
         String fv = featureStr + ':' + valueStr;
 

--- a/core/src/main/java/hivemall/ftvec/FeatureUDF.java
+++ b/core/src/main/java/hivemall/ftvec/FeatureUDF.java
@@ -102,7 +102,7 @@ public final class FeatureUDF extends GenericUDF {
         // Then, toString() works fine
         String featureStr = arg0.toString();
         if (featureStr.indexOf(':') >= 0) {
-            throw new HiveException("feature name SHOULD NOT contain colon: " + featureStr);
+            throw new UDFArgumentException("feature name SHOULD NOT contain colon: " + featureStr);
         }
         String valueStr = arg1.toString();
         String fv = featureStr + ':' + valueStr;

--- a/core/src/test/java/hivemall/ftvec/FeatureUDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/FeatureUDFTest.java
@@ -230,7 +230,7 @@ public class FeatureUDFTest {
         Assert.assertNull(ret);
     }
 
-    @Test(expected = HiveException.class)
+    @Test(expected = UDFArgumentException.class)
     public void testInvalidFeatureName() throws Exception {
         ObjectInspector featureOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
         ObjectInspector weightOI = PrimitiveObjectInspectorFactory.javaDoubleObjectInspector;

--- a/core/src/test/java/hivemall/ftvec/FeatureUDFTest.java
+++ b/core/src/test/java/hivemall/ftvec/FeatureUDFTest.java
@@ -19,6 +19,9 @@
 package hivemall.ftvec;
 
 import hivemall.TestUtils;
+
+import java.io.IOException;
+
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
@@ -30,8 +33,6 @@ import org.apache.hadoop.io.Text;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
 
 public class FeatureUDFTest {
     FeatureUDF udf = null;
@@ -227,7 +228,18 @@ public class FeatureUDFTest {
                 new DeferredJavaObject(null)});
 
         Assert.assertNull(ret);
+    }
 
+    @Test(expected = HiveException.class)
+    public void testInvalidFeatureName() throws Exception {
+        ObjectInspector featureOI = PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+        ObjectInspector weightOI = PrimitiveObjectInspectorFactory.javaDoubleObjectInspector;
+        udf.initialize(new ObjectInspector[] {featureOI, weightOI});
+
+        udf.evaluate(new GenericUDF.DeferredObject[] {new DeferredJavaObject(new Text("f:1")),
+                new DeferredJavaObject(new DoubleWritable(2.5d))});
+
+        Assert.fail();
     }
 
     @Test


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds feature name validation in feature UDF

feature(name, value) should validate name not to include ":". Fail-fast behavior is preferable.

## What type of PR is it?

Hot Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-246

## How was this patch tested?

unit tests

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [ ] Did you run system tests on Hive (or Spark)?
