### PR TITLE
[HIVEMALL-268] Fix the default vInit, eta initialization bug in FactorizationMachines

### DIFF
--- a/core/src/main/java/hivemall/fm/FMArrayModel.java
+++ b/core/src/main/java/hivemall/fm/FMArrayModel.java
@@ -29,7 +29,9 @@ public final class FMArrayModel extends FactorizationMachineModel {
     private final int _p;
 
     // LEARNING PARAMS
+    @Nonnull
     private final float[] _w;
+    @Nonnull
     private final float[][] _V;
 
     public FMArrayModel(@Nonnull FMHyperParameters params) {

--- a/core/src/main/java/hivemall/fm/FMIntFeatureMapModel.java
+++ b/core/src/main/java/hivemall/fm/FMIntFeatureMapModel.java
@@ -34,7 +34,9 @@ public final class FMIntFeatureMapModel extends FactorizationMachineModel {
 
     // LEARNING PARAMS
     private float _w0;
+    @Nonnull
     private final Int2FloatMap _w;
+    @Nonnull
     private final Int2ObjectMap<float[]> _V;
 
     private int _minIndex, _maxIndex;

--- a/core/src/main/java/hivemall/fm/FMStringFeatureMapModel.java
+++ b/core/src/main/java/hivemall/fm/FMStringFeatureMapModel.java
@@ -28,6 +28,7 @@ public final class FMStringFeatureMapModel extends FactorizationMachineModel {
 
     // LEARNING PARAMS
     private float _w0;
+    @Nonnull
     private final Object2ObjectMap<String, Entry> _map;
 
     public FMStringFeatureMapModel(@Nonnull FMHyperParameters params) {

--- a/core/src/main/java/hivemall/fm/FactorizationMachineModel.java
+++ b/core/src/main/java/hivemall/fm/FactorizationMachineModel.java
@@ -23,6 +23,7 @@ import hivemall.utils.lang.NumberUtils;
 import hivemall.utils.math.MathUtils;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Random;
 
 import javax.annotation.Nonnegative;
@@ -36,8 +37,11 @@ public abstract class FactorizationMachineModel {
     protected final boolean _classification;
     protected final int _factor;
     protected final double _sigma;
+    @Nonnull
     protected final EtaEstimator _eta;
+    @Nonnull
     protected final VInitScheme _initScheme;
+    @Nonnull
     protected final Random _rnd;
 
     // Hyperparameter for regression
@@ -47,14 +51,15 @@ public abstract class FactorizationMachineModel {
     // Regulation Variables
     protected float _lambdaW0;
     protected float _lambdaW;
+    @Nonnull
     protected final float[] _lambdaV;
 
     public FactorizationMachineModel(@Nonnull FMHyperParameters params) {
         this._classification = params.classification;
         this._factor = params.factors;
         this._sigma = params.sigma;
-        this._eta = params.eta;
-        this._initScheme = params.vInit;
+        this._eta = Objects.requireNonNull(params.eta);
+        this._initScheme = Objects.requireNonNull(params.vInit);
         this._rnd = new Random(params.seed);
 
         this._min_target = params.minTarget;

--- a/core/src/test/java/hivemall/fm/FieldAwareFactorizationMachineUDTFTest.java
+++ b/core/src/test/java/hivemall/fm/FieldAwareFactorizationMachineUDTFTest.java
@@ -33,6 +33,7 @@ import java.util.zip.GZIPInputStream;
 
 import javax.annotation.Nonnull;
 
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -258,7 +259,7 @@ public class FieldAwareFactorizationMachineUDTFTest {
             cumulativeLoss > udtf._validationState.getCumulativeLoss());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = UDFArgumentException.class)
     public void testUnsupportedAdaptiveRegularizationOption() throws Exception {
         TestUtils.testGenericUDTFSerialization(FieldAwareFactorizationMachineUDTF.class,
             new ObjectInspector[] {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix the default vInit, eta initialization bug in FactorizationMachines

## What type of PR is it?

Bug Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-268

## How was this patch tested?

unit tests, manual tests on EMR

## Checklist

(Please remove this section if not needed; check `x` for YES, blank for NO)

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [ ] Did you run system tests on Hive (or Spark)?
