### PR TITLE
[HIVEMALL-260] Remove dependencies to Scala library in xgboost classifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -271,7 +271,6 @@
 		<dependency.locations.enabled>false</dependency.locations.enabled>
 		<maven-enforcer.requireMavenVersion>[3.3.1,)</maven-enforcer.requireMavenVersion>
 		<surefire.version>2.19.1</surefire.version>
-		<xgboost.version>0.7-rc2</xgboost.version>
 	</properties>
 
 	<distributionManagement>

--- a/xgboost/pom.xml
+++ b/xgboost/pom.xml
@@ -32,7 +32,7 @@
 
 	<properties>
 		<main.basedir>${project.parent.basedir}</main.basedir>
-		<xgboost.version>0.7-rc4</xgboost.version>
+		<xgboost.version>0.7-rc5</xgboost.version>
 	</properties>
 
 	<dependencies>

--- a/xgboost/pom.xml
+++ b/xgboost/pom.xml
@@ -32,6 +32,7 @@
 
 	<properties>
 		<main.basedir>${project.parent.basedir}</main.basedir>
+		<xgboost.version>0.7-rc4</xgboost.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Remove dependencies to Scala library in xgboost classifier

## What type of PR is it?

Bug Fix, Hot Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-260

## How was this patch tested?

manual tests on EMR

## How to use this feature?

to appear

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [ ] Did you run system tests on Hive (or Spark)?
