### PR TITLE
[HIVEMALL-278] Bumped matrix4j version to v0.9.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>io.github.myui</groupId>
 			<artifactId>matrix4j</artifactId>
-			<version>0.9.0</version>
+			<version>0.9.1</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

Bumped matrix4j version to v0.9.1 since matrix4j v0.9.0 had a bug on constructing CSRMatrix in an unordered column order.

## What type of PR is it?

Bug Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-278

## How was this patch tested?

unit tests

## Checklist

(Please remove this section if not needed; check `x` for YES, blank for NO)

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [ ] Did you run system tests on Hive (or Spark)?
