### PR TITLE
[HIVEMALL-249] Fix fmeasure UDAF to support any integers

### DIFF
--- a/core/src/main/java/hivemall/evaluation/FMeasureUDAF.java
+++ b/core/src/main/java/hivemall/evaluation/FMeasureUDAF.java
@@ -45,11 +45,12 @@ import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.primitive.IntObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.io.LongWritable;
 
@@ -239,17 +240,16 @@ public final class FMeasureUDAF extends AbstractGenericUDAFResolver {
                         asIntLabel(parameters[0], (BooleanObjectInspector) actualOI));
                     predicted = Arrays.asList(
                         asIntLabel(parameters[1], (BooleanObjectInspector) predictedOI));
-                } else { // int case
+                } else { // integer case
                     final int actualLabel =
-                            asIntLabel(parameters[0], (IntObjectInspector) actualOI);
+                            asIntLabel(parameters[0], HiveUtils.asIntegerOI(actualOI));
                     if (actualLabel == 0 && "binary".equals(average)) {
                         actual = Collections.emptyList();
                     } else {
                         actual = Arrays.asList(actualLabel);
                     }
-
                     final int predictedLabel =
-                            asIntLabel(parameters[1], (IntObjectInspector) predictedOI);
+                            asIntLabel(parameters[1], HiveUtils.asIntegerOI(predictedOI));
                     if (predictedLabel == 0 && "binary".equals(average)) {
                         predicted = Collections.emptyList();
                     } else {
@@ -270,8 +270,8 @@ public final class FMeasureUDAF extends AbstractGenericUDAFResolver {
         }
 
         private static int asIntLabel(@Nonnull final Object o,
-                @Nonnull final IntObjectInspector intOI) throws UDFArgumentException {
-            final int value = intOI.get(o);
+                @Nonnull final PrimitiveObjectInspector intOI) throws UDFArgumentException {
+            final int value = PrimitiveObjectInspectorUtils.getInt(o, intOI);
             switch (value) {
                 case 1:
                     return 1;


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix fmeasure UDAF to support any integers

## What type of PR is it?

Hot Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-249

## How to use this feature?

```sql
create table data2 as 
  select 1.1 as truth, 0 as predicted
union all
  select 0.0 as truth, 1 as predicted
union all
  select 0.0 as truth, 0 as predicted
union all
  select 1.0 as truth, 1 as predicted
union all
  select 0.0 as truth, 1 as predicted
union all
  select 0.0 as truth, 0 as predicted
;

select fmeasure(truth, predicted, '-average binary') from data;
```

## How was this patch tested?

manual tests on EMR

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
