### PR TITLE
[HIVEMALL-121] Add -libsvm formatting option to feature_hashing UDF

### DIFF
--- a/core/src/main/java/hivemall/ftvec/hashing/FeatureHashingUDF.java
+++ b/core/src/main/java/hivemall/ftvec/hashing/FeatureHashingUDF.java
@@ -137,7 +137,7 @@ public final class FeatureHashingUDF extends UDFWithOptions {
     }
 
     @Nonnull
-    private List<String> evaluateList(@Nonnull final Object arg0) {
+    private List<String> evaluateList(@Nonnull final Object arg0) throws HiveException {
         final int len = _listOI.getListLength(arg0);
         List<String> list = _returnObj;
         if (list == null) {
@@ -158,7 +158,11 @@ public final class FeatureHashingUDF extends UDFWithOptions {
         }
 
         if (_libsvmFormat) {
-            Collections.sort(list, indexCmp);
+            try {
+                Collections.sort(list, indexCmp);
+            } catch (NumberFormatException e) {
+                throw new HiveException(e);
+            }
         }
         return list;
     }

--- a/core/src/main/java/hivemall/ftvec/hashing/FeatureHashingUDF.java
+++ b/core/src/main/java/hivemall/ftvec/hashing/FeatureHashingUDF.java
@@ -46,9 +46,20 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
 
+//@formatter:off
 @Description(name = "feature_hashing",
         value = "_FUNC_(array<string> features [, const string options])"
-                + " - returns a hashed feature vector in array<string>")
+                + " - returns a hashed feature vector in array<string>",
+        extended = "select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-libsvm');\n" + 
+                "> [\"4063537:1.0\",\"4063537:1\",\"8459207:2.0\"]\n" + 
+                "\n" + 
+                "select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-features 10');\n" + 
+                "> [\"7:1.0\",\"7\",\"1:2.0\"]\n" + 
+                "\n" + 
+                "select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-features 10 -libsvm');\n" + 
+                "> [\"1:2.0\",\"7:1.0\",\"7:1\"]\n" + 
+                "")
+//@formatter:on
 @UDFType(deterministic = true, stateful = false)
 public final class FeatureHashingUDF extends UDFWithOptions {
 

--- a/docs/gitbook/ft_engineering/hashing.md
+++ b/docs/gitbook/ft_engineering/hashing.md
@@ -52,6 +52,21 @@ select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'));
 > ["4063537:1.0","4063537","8459207:2.0"]
 
 ```sql
+select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-libsvm');
+```
+> ["4063537:1.0","4063537:1","8459207:2.0"]
+
+```sql
+select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-features 10');
+```
+> ["7:1.0","7","1:2.0"]
+
+```sql
+select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-features 10 -libsvm');
+```
+> ["1:2.0","7:1.0","7:1"]
+
+```sql
 select feature_hashing(array(1,2,3));
 ```
 > ["11293631","3322224","4331412"]
@@ -78,14 +93,16 @@ select feature_hashing(array("userid#4505:3.3","movieid#2331:4.999", "movieid#23
 > ["1828616:3.3","6238429:4.999","6238429"]
 
 ```sql
-select feature_hashing(null,'-help');
+select feature_hashing();
 
 usage: feature_hashing(array<string> features [, const string options]) -
        returns a hashed feature vector in array<string> [-features <arg>]
-       [-help]
+       [-libsvm]
  -features,--num_features <arg>   The number of features [default:
                                   16777217 (2^24)]
- -help                            Show function help
+ -libsvm                          Returns in libsvm format
+                                  (<index>:<value>)* sorted by index
+                                  ascending order
 ```
 
 > #### Note

--- a/docs/gitbook/misc/funcs.md
+++ b/docs/gitbook/misc/funcs.md
@@ -325,6 +325,17 @@ Reference: <a href="https://papers.nips.cc/paper/3848-adaptive-regularization-of
 - `array_hash_values(array<string> values, [string prefix [, int numFeatures], boolean useIndexAsPrefix])` returns hash values in array&lt;int&gt;
 
 - `feature_hashing(array<string> features [, const string options])` - returns a hashed feature vector in array&lt;string&gt;
+  ```sql
+  select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-libsvm');
+  > ["4063537:1.0","4063537:1","8459207:2.0"]
+
+  select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-features 10');
+  > ["7:1.0","7","1:2.0"]
+
+  select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-features 10 -libsvm');
+  > ["1:2.0","7:1.0","7:1"]
+
+  ```
 
 - `mhash(string word)` returns a murmurhash3 INT value starting from 1
 
@@ -636,7 +647,7 @@ Reference: <a href="https://papers.nips.cc/paper/3848-adaptive-regularization-of
 
 # XGBoost
 
-- `train_xgboost(array<string|double> features, int|double target [, string options])` - Returns a relation consists of &lt;string model_id, array&lt;string&gt; pred_model&gt;
+- `train_xgboost(array<string|double> features, <int|double> target, const string options)` - Returns a relation consists of &lt;string model_id, array&lt;string&gt; pred_model&gt;
   ```sql
   SELECT 
     train_xgboost(features, label, '-objective binary:logistic -iters 10') 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `-libsvm` formatting option for `feature_hashing

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-121

## How was this patch tested?

unit tests, manual tests on EMR

## How to use this feature?

```sql
select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-libsvm');
> ["4063537:1.0","4063537:1","8459207:2.0"]

select feature_hashing(array('aaa:1.0','aaa','bbb:2.0'), '-features 10 -libsvm');
> ["1:2.0","7:1.0","7:1"]
```

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
