### PR TITLE
[HIVEMALL-165] Fixed to accept any primitive

### DIFF
--- a/core/src/main/java/hivemall/tools/array/ArrayRemoveUDF.java
+++ b/core/src/main/java/hivemall/tools/array/ArrayRemoveUDF.java
@@ -21,6 +21,7 @@ package hivemall.tools.array;
 import hivemall.utils.hadoop.HiveUtils;
 import hivemall.utils.lang.StringUtils;
 
+import java.util.Collections;
 import java.util.List;
 
 import javax.annotation.Nonnull;
@@ -39,13 +40,36 @@ import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters.C
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 
+//@formatter:off
 @Description(name = "array_remove",
-        value = "_FUNC_(array<PRIMITIVE> original, PRIMITIVE|array<PRIMITIVE> target)"
-                + " - Returns an array that the target is removed " + "from the original array",
-        extended = "SELECT array_remove(array(1,null,3),array(null));\n" + " [1,3]\n" + "\n"
-                + "SELECT array_remove(array(\"aaa\",\"bbb\"),\"bbb\");\n" + " [\"aaa\"]")
+        value = "_FUNC_(array<PRIMITIVE> values, PRIMITIVE|array<PRIMITIVE> target)"
+                + " - Returns an array that the target elements are removed from the original array",
+        extended = "select array_remove(array(2.0,2.1,3.0,4.0,2.0),2), array_remove(array(2.0,3.0,4.0),array(3,2.0));\n" + 
+                "[2.1,3,4]       [4]\n" + 
+                "\n" + 
+                "SELECT array_remove(array(1,null,3),null);\n" + 
+                "[1,3]\n" + 
+                "\n" + 
+                "SELECT array_remove(array(1,null,3,null,5),null);\n" + 
+                "[1,3,5]\n" + 
+                "\n" + 
+                "SELECT array_remove(array(1,null,3),array(null));\n" + 
+                "[1,3]\n" + 
+                "\n" + 
+                "SELECT array_remove(array('aaa','bbb'),'bbb');\n" + 
+                "[\"aaa\"]\n" + 
+                "\n" + 
+                "SELECT array_remove(array('aaa','bbb','ccc','bbb'), array('bbb','ccc'));\n" + 
+                "[\"aaa\"]\n" + 
+                "\n" + 
+                "select array_remove(array(null),null);\n" + 
+                "[]\n" + 
+                "\n" + 
+                "select array_remove(array(null,'bbb'),'aaa');\n" + 
+                "[null,\"bbb\"]")
+//@formatter:on
 @UDFType(deterministic = true, stateful = false)
-public class ArrayRemoveUDF extends GenericUDF {
+public final class ArrayRemoveUDF extends GenericUDF {
 
     private ListObjectInspector valueListOI;
     private PrimitiveObjectInspector valueElemOI;
@@ -82,37 +106,38 @@ public class ArrayRemoveUDF extends GenericUDF {
     public Object evaluate(@Nonnull DeferredObject[] arguments) throws HiveException {
         assert (arguments.length == 2);
 
-        final List<?> values = valueListOI.getList(arguments[0].get());
+        final List<?> values = HiveUtils.copyListObject(arguments[0], valueListOI);
         if (values == null) {
             return null;
         }
 
         final Object target = arguments[1].get();
         if (target == null) {
+            values.removeAll(Collections.singletonList(null));
             return values;
         }
 
         if (isTargetList) {
             Converter converter = ObjectInspectorConverters.getConverter(targetListOI, valueListOI);
-            removeAll(values, target, converter, targetListOI);
+            removeAll(values, target, converter, valueListOI);
         } else {
             Converter converter = ObjectInspectorConverters.getConverter(targetElemOI, valueElemOI);
-            remove(values, target, converter);
+            removeAll(values, target, converter);
         }
         return values;
     }
 
     private static void removeAll(@Nonnull final List<?> values, @Nonnull final Object target,
-            @Nonnull final Converter converter, @Nonnull final ListObjectInspector targetListOI) {
+            @Nonnull final Converter converter, @Nonnull final ListObjectInspector valueListOI) {
         Object converted = converter.convert(target);
-        List<?> toRemove = targetListOI.getList(converted);
-        values.removeAll(toRemove);
+        List<?> convertedList = valueListOI.getList(converted);
+        values.removeAll(convertedList);
     }
 
-    private static void remove(@Nonnull final List<?> values, @Nonnull final Object target,
+    private static void removeAll(@Nonnull final List<?> values, @Nonnull final Object target,
             @Nonnull final Converter converter) {
         Object converted = converter.convert(target);
-        values.remove(converted);
+        values.removeAll(Collections.singleton(converted));
     }
 
     @Override

--- a/core/src/main/java/hivemall/tools/array/ArrayRemoveUDF.java
+++ b/core/src/main/java/hivemall/tools/array/ArrayRemoveUDF.java
@@ -18,35 +18,106 @@
  */
 package hivemall.tools.array;
 
+import hivemall.utils.hadoop.HiveUtils;
+import hivemall.utils.lang.StringUtils;
+
 import java.util.List;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.apache.hadoop.hive.ql.exec.Description;
-import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentLengthException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.udf.UDFType;
-import org.apache.hadoop.io.IntWritable;
-import org.apache.hadoop.io.Text;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorConverters.Converter;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 
 @Description(name = "array_remove",
-        value = "_FUNC_(array<int|text> original, int|text|array<int> target)"
+        value = "_FUNC_(array<PRIMITIVE> original, PRIMITIVE|array<PRIMITIVE> target)"
                 + " - Returns an array that the target is removed " + "from the original array",
-        extended = "SELECT array_remove(array(1,null,3),array(null));\n" + " [3]\n" + "\n"
+        extended = "SELECT array_remove(array(1,null,3),array(null));\n" + " [1,3]\n" + "\n"
                 + "SELECT array_remove(array(\"aaa\",\"bbb\"),\"bbb\");\n" + " [\"aaa\"]")
 @UDFType(deterministic = true, stateful = false)
-public class ArrayRemoveUDF extends UDF {
+public class ArrayRemoveUDF extends GenericUDF {
 
-    public List<IntWritable> evaluate(List<IntWritable> original, IntWritable target) {
-        while (original.remove(target));
-        return original;
+    private ListObjectInspector valueListOI;
+    private PrimitiveObjectInspector valueElemOI;
+    private boolean isTargetList;
+    @Nullable
+    private ListObjectInspector targetListOI;
+    private PrimitiveObjectInspector targetElemOI;
+
+    @Override
+    public ObjectInspector initialize(ObjectInspector[] argOIs) throws UDFArgumentException {
+        if (argOIs.length != 2) {
+            throw new UDFArgumentLengthException("Expected 2 arguments, but got " + argOIs.length);
+        }
+
+        this.valueListOI = HiveUtils.asListOI(argOIs, 0);
+        this.valueElemOI =
+                HiveUtils.asPrimitiveObjectInspector(valueListOI.getListElementObjectInspector());
+
+        if (HiveUtils.isListOI(argOIs[1])) {
+            this.isTargetList = true;
+            this.targetListOI = HiveUtils.asListOI(argOIs, 1);
+            this.targetElemOI = HiveUtils.asPrimitiveObjectInspector(
+                targetListOI.getListElementObjectInspector());
+        } else {
+            this.isTargetList = false;
+            this.targetElemOI = HiveUtils.asPrimitiveObjectInspector(argOIs, 1);
+        }
+
+        return ObjectInspectorFactory.getStandardListObjectInspector(valueElemOI);
     }
 
-    public List<IntWritable> evaluate(List<IntWritable> original, List<IntWritable> targets) {
-        original.removeAll(targets);
-        return original;
+    @Nullable
+    @Override
+    public Object evaluate(@Nonnull DeferredObject[] arguments) throws HiveException {
+        assert (arguments.length == 2);
+
+        final List<?> values = valueListOI.getList(arguments[0].get());
+        if (values == null) {
+            return null;
+        }
+
+        final Object target = arguments[1].get();
+        if (target == null) {
+            return values;
+        }
+
+        if (isTargetList) {
+            Converter converter = ObjectInspectorConverters.getConverter(targetListOI, valueListOI);
+            removeAll(values, target, converter, targetListOI);
+        } else {
+            Converter converter = ObjectInspectorConverters.getConverter(targetElemOI, valueElemOI);
+            remove(values, target, converter);
+        }
+        return values;
     }
 
-    public List<Text> evaluate(List<Text> original, Text target) {
-        while (original.remove(target));
-        return original;
+    private static void removeAll(@Nonnull final List<?> values, @Nonnull final Object target,
+            @Nonnull final Converter converter, @Nonnull final ListObjectInspector targetListOI) {
+        Object converted = converter.convert(target);
+        List<?> toRemove = targetListOI.getList(converted);
+        values.removeAll(toRemove);
+    }
+
+    private static void remove(@Nonnull final List<?> values, @Nonnull final Object target,
+            @Nonnull final Converter converter) {
+        Object converted = converter.convert(target);
+        values.remove(converted);
+    }
+
+    @Override
+    public String getDisplayString(String[] children) {
+        return "array_remove(" + StringUtils.join(children, ',') + ')';
     }
 
 }

--- a/docs/gitbook/misc/generic_funcs.md
+++ b/docs/gitbook/misc/generic_funcs.md
@@ -155,13 +155,31 @@ This page describes a list of useful Hivemall generic functions. See also a [lis
    [3]
   ```
 
-- `array_remove(array<int|text> original, int|text|array<int> target)` - Returns an array that the target is removed from the original array
+- `array_remove(array<PRIMITIVE> values, PRIMITIVE|array<PRIMITIVE> target)` - Returns an array that the target elements are removed from the original array
   ```sql
-  SELECT array_remove(array(1,null,3),array(null));
-   [3]
+  select array_remove(array(2.0,2.1,3.0,4.0,2.0),2), array_remove(array(2.0,3.0,4.0),array(3,2.0));
+  [2.1,3,4]       [4]
 
-  SELECT array_remove(array("aaa","bbb"),"bbb");
-   ["aaa"]
+  SELECT array_remove(array(1,null,3),null);
+  [1,3]
+
+  SELECT array_remove(array(1,null,3,null,5),null);
+  [1,3,5]
+
+  SELECT array_remove(array(1,null,3),array(null));
+  [1,3]
+
+  SELECT array_remove(array('aaa','bbb'),'bbb');
+  ["aaa"]
+
+  SELECT array_remove(array('aaa','bbb','ccc','bbb'), array('bbb','ccc'));
+  ["aaa"]
+
+  select array_remove(array(null),null);
+  []
+
+  select array_remove(array(null,'bbb'),'aaa');
+  [null,"bbb"]
   ```
 
 - `array_slice(array<ANY> values, int offset [, int length])` - Slices the given array by the given offset and length parameters.


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fix a bug that `array_remove` UDF throws exception when the first argument is null

## What type of PR is it?

Bug Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-165

## How was this patch tested?

manual tests on EMR

## How to use this feature?

```sql
WITH data4 as (
  select false as n, array(2.0, 3.0, 4.0) as nums
  union all
   select true as n, array(2.0, 3.0, 4.0) as nums
)
select 
  array_remove(if(n = true, null, nums), 2.0) as c1,
  array_remove(if(n = true, null, nums), array(3.0,2.0)) as c2,
  array_remove(if(n = false, null, nums), 2.0) as c3
from
  data4;
> c1      c2      c3
> [3,4]   [4]     NULL
> NULL    NULL    [3,4]

select array_remove(array(2.0,2.1,3.0,4.0,2.0),2), array_remove(array(2.0,3.0,4.0),array(3,2.0));
> [2.1,3,4]       [4]

SELECT array_remove(array(1,null,3),null);
> [1,3]

SELECT array_remove(array(1,null,3,null,5),null);
> [1,3,5]

SELECT array_remove(array(1,null,3),array(null));
> [1,3]

SELECT array_remove(array('aaa','bbb'),'bbb');
> ["aaa"]

SELECT array_remove(array('aaa','bbb','ccc','bbb'), array('bbb','ccc'));
> ["aaa"]

select array_remove(array(null),null);
> []

select array_remove(array(null,'bbb'),'aaa');
> [null,"bbb"]
```

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
