### PR TITLE
[HIVEMALL-288] mf_predict throws SemanticException No matching method with (array<double>, array<double>, int)

### DIFF
--- a/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
+++ b/core/src/main/java/hivemall/utils/hadoop/HiveUtils.java
@@ -1302,6 +1302,26 @@ public final class HiveUtils {
     }
 
     @Nonnull
+    public static PrimitiveObjectInspector asNumberOI(@Nonnull final ObjectInspector[] argOIs,
+            final int argIndex) throws UDFArgumentException {
+        final PrimitiveObjectInspector oi = asPrimitiveObjectInspector(argOIs, argIndex);
+        switch (oi.getPrimitiveCategory()) {
+            case BYTE:
+            case SHORT:
+            case INT:
+            case LONG:
+            case FLOAT:
+            case DOUBLE:
+            case DECIMAL:
+                break;
+            default:
+                throw new UDFArgumentTypeException(argIndex,
+                    "Only numeric argument is accepted but " + oi.getTypeName() + " is passed.");
+        }
+        return oi;
+    }
+
+    @Nonnull
     public static PrimitiveObjectInspector asNumberOI(@Nonnull final ObjectInspector argOI)
             throws UDFArgumentTypeException {
         if (argOI.getCategory() != Category.PRIMITIVE) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

`mf_predict` throws SemanticException No matching method with (array<double>, array<double>, int)

## What type of PR is it?

Bug Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-288

## How was this patch tested?

manual tests on EMR

```sql
select 
  -- 3 arguments
  mf_predict(array(cast(1.0 as float),cast(2.0 as float),cast(3.0 as float)), array(cast(1.0 as float),cast(2.0 as float),cast(3.0 as float)), 1),
  mf_predict(array(1.0,2.0,3.0), array(1.0,2.0,3.0), 1),
  mf_predict(array(cast(1.0 as DOUBLE),cast(2.0 as DOUBLE),cast(3.0 as DOUBLE)), array(cast(1.0 as DOUBLE),cast(2.0 as DOUBLE),cast(3.0 as DOUBLE)), 1),
  -- 2 arguments
  mf_predict(array(1.0,2.0,3.0), array(1.0,2.0,3.0)),
  -- 4 arguments
  mf_predict(array(1.0,2.0,3.0), array(1.0,2.0,3.0), 0, 0),
  -- 5 arguments
  mf_predict(array(1.0,2.0,3.0), array(1.0,2.0,3.0), 0, 0, 1);
```

## Checklist

(Please remove this section if not needed; check `x` for YES, blank for NO)

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
