### PR TITLE
[HIVEMALL-291] Support deduplication in to_order_list UDAF

### DIFF
--- a/core/src/main/java/hivemall/tools/list/UDAFToOrderedList.java
+++ b/core/src/main/java/hivemall/tools/list/UDAFToOrderedList.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
@@ -567,15 +567,21 @@ public final class UDAFToOrderedList extends AbstractGenericUDAFResolver {
                 }
 
                 final int n = queueHandler.size();
-                final Map<Object, Object> map = new HashMap<>(n * 2);
+                final Object[] keys = new Object[n];
+                final Object[] values = new Object[n];
                 for (int i = n - 1; i >= 0; i--) { // head element in queue should be stored to tail of array
                     TupleWithKey tuple = queueHandler.poll();
-                    Object k = tuple.getKey();
+                    keys[i] = tuple.getKey();
+                    values[i] = tuple.getValue();
+                }
+
+                final Map<Object, Object> map = new LinkedHashMap<>(n * 2);
+                for (int i = 0; i < n; i++) {
+                    final Object k = keys[i];
                     if (map.containsKey(k)) {
-                        continue; // avoid duplicate
+                        continue;
                     }
-                    Object v = tuple.getValue();
-                    map.put(k, v);
+                    map.put(k, values[i]);
                 }
                 queueHandler.clear();
 
@@ -589,15 +595,21 @@ public final class UDAFToOrderedList extends AbstractGenericUDAFResolver {
                 }
 
                 final int n = queueHandler.size();
-                final Map<Object, Object> map = new HashMap<>(n * 2);
+                final Object[] keys = new Object[n];
+                final Object[] values = new Object[n];
                 for (int i = n - 1; i >= 0; i--) { // head element in queue should be stored to tail of array
                     TupleWithKey tuple = queueHandler.poll();
-                    Object k = tuple.getValue();
+                    keys[i] = tuple.getValue();
+                    values[i] = tuple.getKey();
+                }
+
+                final Map<Object, Object> map = new LinkedHashMap<>(n * 2);
+                for (int i = 0; i < n; i++) {
+                    final Object k = keys[i];
                     if (map.containsKey(k)) {
                         continue; // avoid duplicate
                     }
-                    Object v = tuple.getKey();
-                    map.put(k, v);
+                    map.put(k, values[i]);
                 }
                 queueHandler.clear();
 

--- a/core/src/main/java/hivemall/tools/list/UDAFToOrderedList.java
+++ b/core/src/main/java/hivemall/tools/list/UDAFToOrderedList.java
@@ -72,27 +72,41 @@ import org.apache.hadoop.io.IntWritable;
 @Description(name = "to_ordered_list",
         value = "_FUNC_(PRIMITIVE value [, PRIMITIVE key, const string options])"
                 + " - Return list of values sorted by value itself or specific key",
-        extended = "WITH t as (\n" + "    SELECT 5 as key, 'apple' as value\n" + "    UNION ALL\n"
-                + "    SELECT 3 as key, 'banana' as value\n" + "    UNION ALL\n"
-                + "    SELECT 4 as key, 'candy' as value\n" + "    UNION ALL\n"
-                + "    SELECT 2 as key, 'donut' as value\n" + "    UNION ALL\n"
-                + "    SELECT 3 as key, 'egg' as value\n" + ")\n"
-                + "SELECT                                             -- expected output\n"
-                + "    to_ordered_list(value, key, '-reverse'),       -- [apple, candy, (banana, egg | egg, banana), donut] (reverse order)\n"
-                + "    to_ordered_list(value, key, '-k 2'),           -- [apple, candy] (top-k)\n"
-                + "    to_ordered_list(value, key, '-k 100'),         -- [apple, candy, (banana, egg | egg, banana), dunut]\n"
-                + "    to_ordered_list(value, key, '-k 2 -reverse'),  -- [donut, (banana | egg)] (reverse top-k = tail-k)\n"
-                + "    to_ordered_list(value, key),                   -- [donut, (banana, egg | egg, banana), candy, apple] (natural order)\n"
-                + "    to_ordered_list(value, key, '-k -2'),          -- [donut, (banana | egg)] (tail-k)\n"
-                + "    to_ordered_list(value, key, '-k -100'),        -- [donut, (banana, egg | egg, banana), candy, apple]\n"
-                + "    to_ordered_list(value, key, '-k -2 -reverse'), -- [apple, candy] (reverse tail-k = top-k)\n"
-                + "    to_ordered_list(value, '-k 2'),                -- [egg, donut] (alphabetically)\n"
-                + "    to_ordered_list(key, '-k -2 -reverse'),        -- [5, 4] (top-2 keys)\n"
-                + "    to_ordered_list(key),                          -- [2, 3, 3, 4, 5] (natural ordered keys)\n"
-                + "    to_ordered_list(value, key, '-k 2 -kv_map'),   -- {4:\"candy\",5:\"apple\"}\n"
-                + "    to_ordered_list(value, key, '-k 2 -vk_map')    -- {\"candy\":4,\"apple\":5}\n"
-                + "    to_ordered_list(value, key, '-dedup -vk_map')  -- "
-                + "FROM\n" + "    t")
+        extended = "WITH data as (\n" + 
+                "    SELECT 5 as key, 'apple' as value\n" + 
+                "    UNION ALL\n" + 
+                "    SELECT 3 as key, 'banana' as value\n" + 
+                "    UNION ALL\n" + 
+                "    SELECT 4 as key, 'candy' as value\n" + 
+                "    UNION ALL\n" + 
+                "    SELECT 1 as key, 'donut' as value\n" + 
+                "    UNION ALL\n" + 
+                "    SELECT 2 as key, 'egg' as value \n" + 
+                "    UNION ALL\n" + 
+                "    SELECT 4 as key, 'candy' as value -- both key and value duplicates\n" + 
+                ")\n" + 
+                "SELECT                                                  -- expected output\n" + 
+                "    to_ordered_list(value, key, '-reverse'),            -- [apple, candy, (banana, egg | egg, banana), donut] (reverse order)\n" + 
+                "    to_ordered_list(value, key, '-k 2'),                -- [apple, candy] (top-k)\n" + 
+                "    to_ordered_list(value, key, '-k 100'),              -- [apple, candy, (banana, egg | egg, banana), dunut]\n" + 
+                "    to_ordered_list(value, key, '-k 2 -reverse'),       -- [donut, (banana | egg)] (reverse top-k = tail-k)\n" + 
+                "    to_ordered_list(value, key),                        -- [donut, (banana, egg | egg, banana), candy, apple] (natural order)\n" + 
+                "    to_ordered_list(value, key, '-k -2'),               -- [donut, (banana | egg)] (tail-k)\n" + 
+                "    to_ordered_list(value, key, '-k -100'),             -- [donut, (banana, egg | egg, banana), candy, apple]\n" + 
+                "    to_ordered_list(value, key, '-k -2 -reverse'),      -- [apple, candy] (reverse tail-k = top-k)\n" + 
+                "    to_ordered_list(value, '-k 2'),                     -- [egg, donut] (alphabetically)\n" + 
+                "    to_ordered_list(key, '-k -2 -reverse'),             -- [5, 4] (top-2 keys)\n" + 
+                "    to_ordered_list(key),                               -- [2, 3, 3, 4, 5] (natural ordered keys)\n" + 
+                "    to_ordered_list(value, key, '-k 2 -kv_map'),        -- {5:\"apple\",4:\"candy\"}\n" + 
+                "    to_ordered_list(value, key, '-k 2 -vk_map'),        -- {\"apple\":5,\"candy\":4}\n" + 
+                "    to_ordered_list(value, key, '-k -2 -kv_map'),       -- {1:\"donut\",2:\"egg\"}\n" + 
+                "    to_ordered_list(value, key, '-k -2 -vk_map'),       -- {\"donut\":1,\"egg\":2}\n" + 
+                "    to_ordered_list(value, key, '-k 4 -dedup -vk_map'), -- {\"apple\":5,\"candy\":4,\"banana\":3,\"egg\":2}\n" + 
+                "    to_ordered_list(value, key, '-k 4 -vk_map'),        -- {\"apple\":5,\"candy\":4,\"banana\":3}\n" + 
+                "    to_ordered_list(value, key, '-k 4 -dedup'),         -- [\"apple\",\"candy\",\"banana\",\"egg\"]\n" + 
+                "    to_ordered_list(value, key, '-k 4')                 -- [\"apple\",\"candy\",\"candy\",\"banana\"]\n" + 
+                "FROM\n" + 
+                "    data")
 //@formatter:on
 public final class UDAFToOrderedList extends AbstractGenericUDAFResolver {
 

--- a/core/src/main/java/hivemall/utils/collections/BoundedPriorityQueue.java
+++ b/core/src/main/java/hivemall/utils/collections/BoundedPriorityQueue.java
@@ -45,6 +45,10 @@ public final class BoundedPriorityQueue<E> {
         this.comparator = comparator;
         this.queue = new PriorityQueue<E>(size + 10, comparator);
     }
+    
+    public boolean contains(@Nonnull E e) {
+        return queue.contains(e);
+    }
 
     public boolean offer(@Nonnull E e) {
         if (e == null) {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add -dedup option to to_ordered_list.

## What type of PR is it?

Improvement

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-291

## How was this patch tested?

manual tests on EMR

## How to use this feature?

```sql
WITH data as (
    SELECT 5 as key, 'apple' as value
    UNION ALL
    SELECT 3 as key, 'banana' as value
    UNION ALL
    SELECT 4 as key, 'candy' as value
    UNION ALL
    SELECT 1 as key, 'donut' as value
    UNION ALL
    SELECT 2 as key, 'egg' as value 
    UNION ALL
    SELECT 4 as key, 'candy' as value -- both key and value duplicates
)
select 
  to_ordered_list(value, key, '-k 4 -dedup -vk_map'),
  to_ordered_list(value, key, '-k 4 -vk_map'),
  to_ordered_list(value, key, '-k 4 -dedup'),
  to_ordered_list(value, key, '-k 4')
from
  data
```

> {"apple":5,"candy":4,"banana":3,"egg":2}        {"apple":5,"candy":4,"banana":3}        ["apple","candy","banana","egg"]      [
"apple","candy","candy","banana"]

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
