### PR TITLE
 [HIVEMALL-291] Fixed dedup behavior of to_ordered_list UDAF

### DIFF
--- a/core/src/main/java/hivemall/tools/list/UDAFToOrderedList.java
+++ b/core/src/main/java/hivemall/tools/list/UDAFToOrderedList.java
@@ -86,17 +86,17 @@ import org.apache.hadoop.io.IntWritable;
                 "    SELECT 4 as key, 'candy' as value -- both key and value duplicates\n" + 
                 ")\n" + 
                 "SELECT                                                  -- expected output\n" + 
-                "    to_ordered_list(value, key, '-reverse'),            -- [apple, candy, (banana, egg | egg, banana), donut] (reverse order)\n" + 
+                "    to_ordered_list(value, key, '-reverse'),            -- [apple, candy, candy, (banana, egg | egg, banana), donut] (reverse order)\n" + 
                 "    to_ordered_list(value, key, '-k 2'),                -- [apple, candy] (top-k)\n" + 
-                "    to_ordered_list(value, key, '-k 100'),              -- [apple, candy, (banana, egg | egg, banana), dunut]\n" + 
+                "    to_ordered_list(value, key, '-k 100'),              -- [apple, candy, candy, (banana, egg | egg, banana), dunut]\n" + 
                 "    to_ordered_list(value, key, '-k 2 -reverse'),       -- [donut, (banana | egg)] (reverse top-k = tail-k)\n" + 
-                "    to_ordered_list(value, key),                        -- [donut, (banana, egg | egg, banana), candy, apple] (natural order)\n" + 
+                "    to_ordered_list(value, key),                        -- [donut, (banana, egg | egg, banana), candy, candy, apple] (natural order)\n" + 
                 "    to_ordered_list(value, key, '-k -2'),               -- [donut, (banana | egg)] (tail-k)\n" + 
-                "    to_ordered_list(value, key, '-k -100'),             -- [donut, (banana, egg | egg, banana), candy, apple]\n" + 
+                "    to_ordered_list(value, key, '-k -100'),             -- [donut, (banana, egg | egg, banana), candy, candy, apple]\n" + 
                 "    to_ordered_list(value, key, '-k -2 -reverse'),      -- [apple, candy] (reverse tail-k = top-k)\n" + 
                 "    to_ordered_list(value, '-k 2'),                     -- [egg, donut] (alphabetically)\n" + 
                 "    to_ordered_list(key, '-k -2 -reverse'),             -- [5, 4] (top-2 keys)\n" + 
-                "    to_ordered_list(key),                               -- [2, 3, 3, 4, 5] (natural ordered keys)\n" + 
+                "    to_ordered_list(key),                               -- [1, 2, 3, 4, 4, 5] (natural ordered keys)\n" + 
                 "    to_ordered_list(value, key, '-k 2 -kv_map'),        -- {5:\"apple\",4:\"candy\"}\n" + 
                 "    to_ordered_list(value, key, '-k 2 -vk_map'),        -- {\"apple\":5,\"candy\":4}\n" + 
                 "    to_ordered_list(value, key, '-k -2 -kv_map'),       -- {1:\"donut\",2:\"egg\"}\n" + 

--- a/core/src/test/java/hivemall/tools/list/UDAFToOrderedListTest.java
+++ b/core/src/test/java/hivemall/tools/list/UDAFToOrderedListTest.java
@@ -22,6 +22,7 @@ import hivemall.tools.list.UDAFToOrderedList.UDAFToOrderedListEvaluator;
 import hivemall.tools.list.UDAFToOrderedList.UDAFToOrderedListEvaluator.QueueAggregationBuffer;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -499,7 +500,7 @@ public class UDAFToOrderedListTest {
 
         Object result = evaluator.terminate(agg);
 
-        Assert.assertEquals(HashMap.class, result.getClass());
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
         Map<?, ?> map = (Map<?, ?>) result;
         Assert.assertEquals(2, map.size());
 
@@ -528,7 +529,7 @@ public class UDAFToOrderedListTest {
 
         Object result = evaluator.terminate(agg);
 
-        Assert.assertEquals(HashMap.class, result.getClass());
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
         Map<?, ?> map = (Map<?, ?>) result;
         Assert.assertEquals(2, map.size());
 
@@ -557,7 +558,7 @@ public class UDAFToOrderedListTest {
 
         Object result = evaluator.terminate(agg);
 
-        Assert.assertEquals(HashMap.class, result.getClass());
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
         Map<?, ?> map = (Map<?, ?>) result;
         Assert.assertEquals(2, map.size());
 
@@ -586,7 +587,7 @@ public class UDAFToOrderedListTest {
 
         Object result = evaluator.terminate(agg);
 
-        Assert.assertEquals(HashMap.class, result.getClass());
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
         Map<?, ?> map = (Map<?, ?>) result;
         Assert.assertEquals(1, map.size());
 
@@ -614,7 +615,7 @@ public class UDAFToOrderedListTest {
 
         Object result = evaluator.terminate(agg);
 
-        Assert.assertEquals(HashMap.class, result.getClass());
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
         Map<?, ?> map = (Map<?, ?>) result;
         Assert.assertEquals(2, map.size());
 
@@ -643,7 +644,7 @@ public class UDAFToOrderedListTest {
 
         Object result = evaluator.terminate(agg);
 
-        Assert.assertEquals(HashMap.class, result.getClass());
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
         Map<?, ?> map = (Map<?, ?>) result;
         Assert.assertEquals(2, map.size());
 
@@ -672,7 +673,7 @@ public class UDAFToOrderedListTest {
 
         Object result = evaluator.terminate(agg);
 
-        Assert.assertEquals(HashMap.class, result.getClass());
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
         Map<?, ?> map = (Map<?, ?>) result;
         Assert.assertEquals(2, map.size());
 
@@ -701,7 +702,7 @@ public class UDAFToOrderedListTest {
 
         Object result = evaluator.terminate(agg);
 
-        Assert.assertEquals(HashMap.class, result.getClass());
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
         Map<?, ?> map = (Map<?, ?>) result;
         Assert.assertEquals(2, map.size());
 
@@ -730,7 +731,7 @@ public class UDAFToOrderedListTest {
 
         Object result = evaluator.terminate(agg);
 
-        Assert.assertEquals(HashMap.class, result.getClass());
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
         Map<?, ?> map = (Map<?, ?>) result;
         Assert.assertEquals(2, map.size());
 

--- a/core/src/test/java/hivemall/tools/list/UDAFToOrderedListTest.java
+++ b/core/src/test/java/hivemall/tools/list/UDAFToOrderedListTest.java
@@ -21,7 +21,6 @@ package hivemall.tools.list;
 import hivemall.tools.list.UDAFToOrderedList.UDAFToOrderedListEvaluator;
 import hivemall.tools.list.UDAFToOrderedList.UDAFToOrderedListEvaluator.QueueAggregationBuffer;
 
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -624,6 +623,34 @@ public class UDAFToOrderedListTest {
     }
 
     @Test
+    public void testVKMapOptionNaturalOrder() throws Exception {
+        ObjectInspector[] inputOIs =
+                new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
+                        PrimitiveObjectInspectorFactory.javaDoubleObjectInspector,
+                        ObjectInspectorUtils.getConstantObjectInspector(
+                            PrimitiveObjectInspectorFactory.javaStringObjectInspector, "-vk_map")};
+
+        final String[] values = new String[] {"banana", "apple", "banana"};
+        final double[] keys = new double[] {0.7, 0.6, 0.8};
+
+        evaluator.init(GenericUDAFEvaluator.Mode.PARTIAL1, inputOIs);
+        evaluator.reset(agg);
+
+        for (int i = 0; i < values.length; i++) {
+            evaluator.iterate(agg, new Object[] {values[i], keys[i]});
+        }
+
+        Object result = evaluator.terminate(agg);
+
+        Assert.assertEquals(LinkedHashMap.class, result.getClass());
+        Map<?, ?> map = (Map<?, ?>) result;
+        Assert.assertEquals(2, map.size());
+
+        Assert.assertEquals(0.6d, map.get("apple"));
+        Assert.assertEquals(0.7d, map.get("banana"));
+    }
+
+    @Test
     public void testVKMapOptionReverseOrder() throws Exception {
         ObjectInspector[] inputOIs =
                 new ObjectInspector[] {PrimitiveObjectInspectorFactory.javaStringObjectInspector,
@@ -649,7 +676,7 @@ public class UDAFToOrderedListTest {
         Assert.assertEquals(2, map.size());
 
         Assert.assertEquals(0.6d, map.get("apple"));
-        Assert.assertEquals(0.7d, map.get("banana"));
+        Assert.assertEquals(0.8d, map.get("banana"));
     }
 
     @Test

--- a/docs/gitbook/misc/funcs.md
+++ b/docs/gitbook/misc/funcs.md
@@ -199,7 +199,7 @@ Reference: <a href="https://papers.nips.cc/paper/3848-adaptive-regularization-of
 
 - `bprmf_predict(List<Float> Pu, List<Float> Qi[, double Bi])` - Returns the prediction value
 
-- `mf_predict(List<Float> Pu, List<Float> Qi[, double Bu, double Bi[, double mu]])` - Returns the prediction value
+- `mf_predict(array<double> Pu, array<double> Qi[, double Bu, double Bi[, double mu]])` - Returns the prediction value
 
 - `train_bprmf(INT user, INT posItem, INT negItem [, String options])` - Returns a relation &lt;INT i, FLOAT Pi, FLOAT Qi [, FLOAT Bi]&gt;
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed dedup behavior of to_ordered_list UDAF

## What type of PR is it?

Hot Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-291

## How was this patch tested?

unit tests

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [x] Did you run system tests on Hive (or Spark)?
