### PR TITLE
[HIVEMALL-296][BUGFIX] Fixed corner case NPE bug when count is zero

### DIFF
--- a/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
+++ b/core/src/main/java/hivemall/GeneralLearnerBaseUDTF.java
@@ -565,7 +565,6 @@ public abstract class GeneralLearnerBaseUDTF extends LearnerBaseUDTF {
     @VisibleForTesting
     public void finalizeTraining() throws HiveException {
         if (count == 0L) {
-            this.model = null;
             return;
         }
         if (is_mini_batch) { // Update model with accumulated delta

--- a/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
+++ b/core/src/test/java/hivemall/classifier/GeneralClassifierUDTFTest.java
@@ -950,6 +950,26 @@ public class GeneralClassifierUDTFTest {
             udtf.getCumulativeLoss() < 900);
     }
 
+    @Test
+    public void testNPE_HIVEMALL296() throws IOException, HiveException {
+        String options =
+                "-loss logloss -opt sgd -reg l1 -lambda 0.0001 -iter 10 -mini_batch 1 -cv_rate 0.00005";
+
+        GeneralClassifierUDTF udtf = new GeneralClassifierUDTF();
+
+        ListObjectInspector stringListOI = ObjectInspectorFactory.getStandardListObjectInspector(
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector);
+        ObjectInspector params = ObjectInspectorUtils.getConstantObjectInspector(
+            PrimitiveObjectInspectorFactory.javaStringObjectInspector, options);
+
+        udtf.initialize(new ObjectInspector[] {stringListOI,
+                PrimitiveObjectInspectorFactory.javaIntObjectInspector, params});
+
+        udtf.close();
+
+        Assert.assertTrue("NPE should not occour", true);
+    }
+
     private static void println(String msg) {
         if (DEBUG) {
             System.out.println(msg);


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixed corner case NPE bug when count is zero.

```
Caused by: java.lang.NullPointerException
	at hivemall.GeneralLearnerBaseUDTF.forwardModel(GeneralLearnerBaseUDTF.java:763)
	at hivemall.GeneralLearnerBaseUDTF.close(GeneralLearnerBaseUDTF.java:560)
	at org.apache.hadoop.hive.ql.exec.UDTFOperator.closeOp(UDTFOperator.java:152)
	at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:697)
	at org.apache.hadoop.hive.ql.exec.Operator.close(Operator.java:711)
	at org.apache.hadoop.hive.ql.exec.mr.ExecReducer.close(ExecReducer.java:279)
```

## What type of PR is it?

Bug Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-296

## How was this patch tested?

unit tests

## Checklist

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [ ] Did you run system tests on Hive (or Spark)?
