### PR TITLE
[HIVEMALL-311] Upgrade Kryo version from 2.21 to 2.24.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -163,6 +163,12 @@
 			<artifactId>mockito-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.esotericsoftware.kryo</groupId>
+			<artifactId>kryo</artifactId>
+			<version>${kryo.version}</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/core/src/test/java/hivemall/TestUtils.java
+++ b/core/src/test/java/hivemall/TestUtils.java
@@ -162,9 +162,14 @@ public final class TestUtils {
     @Nonnull
     private static com.esotericsoftware.kryo.Kryo getOriginalKryo() {
         com.esotericsoftware.kryo.Kryo kryo = new com.esotericsoftware.kryo.Kryo();
+
         // kryo.setReferences(true);
         // kryo.setRegistrationRequired(false);
-        kryo.setInstantiatorStrategy(new StdInstantiatorStrategy());
+
+        // see https://stackoverflow.com/a/23962797/5332768
+        ((com.esotericsoftware.kryo.Kryo.DefaultInstantiatorStrategy) kryo.getInstantiatorStrategy()).setFallbackInstantiatorStrategy(
+            new StdInstantiatorStrategy());
+
         return kryo;
     }
 

--- a/core/src/test/java/hivemall/TestUtils.java
+++ b/core/src/test/java/hivemall/TestUtils.java
@@ -49,8 +49,8 @@ public final class TestUtils {
         udf.initialize(ois);
 
         // serialization after initialization
-        byte[] serialized = serializeObjectByKryo(udf);
-        deserializeObjectByKryo(serialized, clazz);
+        byte[] serialized1 = serializeObjectByKryo(udf);
+        deserializeObjectByKryo(serialized1, clazz);
 
         byte[] serialized2 = serializeObjectByOriginalKryo(udf);
         deserializeObjectByOriginalKryo(serialized2, clazz);
@@ -64,8 +64,11 @@ public final class TestUtils {
         udf.evaluate(rowDeferred);
 
         // serialization after evaluating row
-        serialized = serializeObjectByKryo(udf);
-        TestUtils.deserializeObjectByKryo(serialized, clazz);
+        serialized1 = serializeObjectByKryo(udf);
+        TestUtils.deserializeObjectByKryo(serialized1, clazz);
+
+        serialized2 = serializeObjectByOriginalKryo(udf);
+        TestUtils.deserializeObjectByOriginalKryo(serialized2, clazz);
 
         udf.close();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
 		<maven-enforcer.requireMavenVersion>[3.3.1,)</maven-enforcer.requireMavenVersion>
 		<surefire.version>2.19.1</surefire.version>
 		<netty.version>4.1.42.Final</netty.version>
-		<kryo.version>2.21</kryo.version>
+		<kryo.version>2.24.0</kryo.version>
 	</properties>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,7 @@
 		<maven-enforcer.requireMavenVersion>[3.3.1,)</maven-enforcer.requireMavenVersion>
 		<surefire.version>2.19.1</surefire.version>
 		<netty.version>4.1.42.Final</netty.version>
+		<kryo.version>2.24.0</kryo.version>
 	</properties>
 
 	<distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -272,7 +272,7 @@
 		<maven-enforcer.requireMavenVersion>[3.3.1,)</maven-enforcer.requireMavenVersion>
 		<surefire.version>2.19.1</surefire.version>
 		<netty.version>4.1.42.Final</netty.version>
-		<kryo.version>2.24.0</kryo.version>
+		<kryo.version>2.21</kryo.version>
 	</properties>
 
 	<distributionManagement>

--- a/xgboost/pom.xml
+++ b/xgboost/pom.xml
@@ -97,7 +97,7 @@
 			<!-- NOTE: This dependency needed for xgboost4j -->
 			<groupId>com.esotericsoftware.kryo</groupId>
 			<artifactId>kryo</artifactId>
-			<version>2.21</version>
+			<version>${kryo.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
## What changes were proposed in this pull request?

xgboost4j and xgboost module used Kryo version 2.21 but it has a bug in serializing generic collections. So, update Kryo version to 2.24.0 just in case.

## What type of PR is it?

Bug Fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-311

## How was this patch tested?

unit tests

## Checklist

(Please remove this section if not needed; check `x` for YES, blank for NO)

- [x] Did you apply source code formatter, i.e., `./bin/format_code.sh`, for your commit?
- [ ] Did you run system tests on Hive (or Spark)?
