### PR TITLE
[HIVEMALL-312] Changed default constructor accessor to public for Spark

### DIFF
--- a/core/src/main/java/hivemall/factorization/fm/FFMPredictGenericUDAF.java
+++ b/core/src/main/java/hivemall/factorization/fm/FFMPredictGenericUDAF.java
@@ -49,7 +49,9 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
                 + " - Returns a prediction value in Double")
 public final class FFMPredictGenericUDAF extends AbstractGenericUDAFResolver {
 
-    private FFMPredictGenericUDAF() {}
+    public FFMPredictGenericUDAF() {
+        super();
+    }
 
     @Override
     public Evaluator getEvaluator(@Nonnull TypeInfo[] typeInfo) throws SemanticException {

--- a/core/src/main/java/hivemall/factorization/fm/FMPredictGenericUDAF.java
+++ b/core/src/main/java/hivemall/factorization/fm/FMPredictGenericUDAF.java
@@ -60,7 +60,9 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
         value = "_FUNC_(Float Wj, array<float> Vjf, float Xj) - Returns a prediction value in Double")
 public final class FMPredictGenericUDAF extends AbstractGenericUDAFResolver {
 
-    private FMPredictGenericUDAF() {}
+    public FMPredictGenericUDAF() {
+        super();
+    }
 
     @Override
     public Evaluator getEvaluator(TypeInfo[] typeInfo) throws SemanticException {


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changed default constructor accessor to public for Spark

```
Exception in thread "main" org.apache.spark.sql.AnalysisException: No handler for UDF/UDAF/UDTF 'hivemall.factorization.fm.FMPredictGenericUDAF': java.lang.IllegalAccessException: Class org.apache.spark.sql.hive.HiveShim$HiveFunctionWrapper can not access a member of class hivemall.factorization.fm.FMPredictGenericUDAF with modifiers "private"; line 6 pos 0Exception in thread "main" org.apache.spark.sql.AnalysisException: No handler for UDF/UDAF/UDTF 'hivemall.factorization.fm.FMPredictGenericUDAF': java.lang.IllegalAccessException: Class org.apache.spark.sql.hive.HiveShim$HiveFunctionWrapper can not access a member of class hivemall.factorization.fm.FMPredictGenericUDAF with modifiers "private"; line 6 pos 0 at sun.reflect.Reflection.ensureMemberAccess(Reflection.java:102) at java.lang.Class.newInstance(Class.java:436) at org.apache.spark.sql.hive.HiveShim$HiveFunctionWrapper.createFunction(HiveShim.scala:220) at org.apache.spark.sql.hive.HiveUDAFFunction.newEvaluator(hiveUDFs.scala:343) at org.apache.spark.sql.hive.HiveUDAFFunction.org$apache$spark$sql$hive$HiveUDAFFunction$$finalHiveEvaluator$lzycompute(hiveUDFs.scala:366) at org.apache.spark.sql.hive.HiveUDAFFunction.org$apache$spark$sql$hive$HiveUDAFFunction$$finalHiveEvaluator(hiveUDFs.scala:365) at org.apache.spark.sql.hive.HiveUDAFFunction.dataType$lzycompute(hiveUDFs.scala:394) at org.apache.spark.sql.hive.HiveUDAFFunction.dataType(hiveUDFs.scala:394) at org.apache.spark.sql.hive.HiveSessionCatalog$$anonfun$makeFunctionExpression$1$$anonfun$apply$2.apply(HiveSessionCatalog.scala:85) at org.apache.spark.sql.hive.HiveSessionCatalog$$anonfun$makeFunctionExpression$1$$anonfun$apply$2.apply(HiveSessionCatalog.scala:71) at scala.util.Try.getOrElse(Try.scala:79) at org.apache.spark.sql.hive.HiveSessionCatalog$$anonfun$makeFunctionExpression$1.apply(HiveSessionCatalog.scala:71) at org.apache.spark.sql.hive.HiveSessionCatalog$$anonfun$makeFunctionExpression$1.apply(HiveSessionCatalog.scala:71) at 
```

## What type of PR is it?

Bug Fix, Hot fix

## What is the Jira issue?

https://issues.apache.org/jira/browse/HIVEMALL-312

## How was this patch tested?

unit tests