### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -781,7 +781,7 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<configuration>
 					<enableAssertions>true</enableAssertions>
-					<forkCount>1</forkCount>
+					<forkCount>1.5C</forkCount>
 					<reuseForks>false</reuseForks>
 					<forkedProcessTimeoutInSeconds>600</forkedProcessTimeoutInSeconds>
 					<argLine>-Xmx1536m -XX:+HeapDumpOnOutOfMemoryError</argLine>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
